### PR TITLE
Controlled Vocabularies

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -56,6 +56,8 @@ gem 'hydra-editor'
 
 gem 'docsplit'
 
+gem 'attr_extras'
+
 
 group :development, :test do
   # Access an IRB console on exception pages or by using <%= console %> in views

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -120,6 +120,7 @@ GEM
       tzinfo (~> 1.1)
     addressable (2.3.8)
     arel (6.0.0)
+    attr_extras (4.4.0)
     autoprefixer-rails (5.1.9)
       execjs
       json
@@ -511,6 +512,7 @@ PLATFORMS
 DEPENDENCIES
   active-fedora!
   active_fedora-noid
+  attr_extras
   blacklight
   blacklight_advanced_search
   capybara

--- a/app/decorators/decorate_properties.rb
+++ b/app/decorators/decorate_properties.rb
@@ -1,0 +1,26 @@
+class DecorateProperties
+  pattr_initialize :resource, :property_mapper
+  
+  def run
+    temp_resource = resource
+    property_mapper.to_a.map{|x| PropertyValidator.new(*x) }.each do |p|
+      temp_resource = p.decorate_resource(temp_resource)
+    end
+    temp_resource
+  end
+end
+
+class PropertyValidator
+  attr_reader :property, :validators
+  def initialize(property, validators)
+    @property = property
+    @validators = Array.wrap(validators)
+  end
+
+  def decorate_resource(resource)
+    validators.each do |validator|
+      resource = WithValidatedProperty.new(resource, property, validator)
+    end
+    resource
+  end
+end

--- a/app/decorators/with_validated_property.rb
+++ b/app/decorators/with_validated_property.rb
@@ -6,12 +6,17 @@ class WithValidatedProperty < SimpleDelegator
     @validator = validator
   end
 
-  def valid?
-    __getobj__.valid?
+  def valid?(*args)
+    __getobj__.valid?(*args)
     unless validator.valid?(result)
       errors.add(property, validator.message)
     end
     errors.blank?
+  end
+
+  def save(*args)
+    return false unless valid?
+    __getobj__.save(*args)
   end
 
   private

--- a/app/decorators/with_validated_property.rb
+++ b/app/decorators/with_validated_property.rb
@@ -1,0 +1,22 @@
+class WithValidatedProperty < SimpleDelegator
+  attr_reader :property, :validator
+  def initialize(resource, property, validator)
+    super(resource)
+    @property = property
+    @validator = validator
+  end
+
+  def valid?
+    __getobj__.valid?
+    unless validator.valid?(result)
+      errors.add(property, validator.message)
+    end
+    errors.blank?
+  end
+
+  private
+
+  def result
+    get_values(property, :cast => false)
+  end
+end

--- a/app/repositories/validated_asset_repository.rb
+++ b/app/repositories/validated_asset_repository.rb
@@ -24,7 +24,7 @@ class ValidatedAssetRepository
   def validations
     {
       :lcsubject => [
-        LcshValidator.new
+        SubjectCvValidator.new
       ]
     }
   end

--- a/app/repositories/validated_asset_repository.rb
+++ b/app/repositories/validated_asset_repository.rb
@@ -22,10 +22,7 @@ class ValidatedAssetRepository
   end
 
   def validations
-    {
-      :lcsubject => [
-        SubjectCvValidator.new
-      ]
-    }
+    @validations ||= 
+      PropertyValidationsGenerator.new(base_repository).validations
   end
 end

--- a/app/repositories/validated_asset_repository.rb
+++ b/app/repositories/validated_asset_repository.rb
@@ -1,0 +1,31 @@
+class ValidatedAssetRepository
+  pattr_initialize :base_repository
+
+  def new(*args)
+    property_decorator.new(
+      base_repository.new(*args),
+      validations
+    ).run
+  end
+
+  def find(*args)
+    property_decorator.new(
+      base_repository.find(*args),
+      validations
+    ).run
+  end
+
+  private
+
+  def property_decorator
+    DecorateProperties
+  end
+
+  def validations
+    {
+      :lcsubject => [
+        LcshValidator.new
+      ]
+    }
+  end
+end

--- a/app/repositories/validated_asset_repository.rb
+++ b/app/repositories/validated_asset_repository.rb
@@ -2,15 +2,16 @@ class ValidatedAssetRepository
   pattr_initialize :base_repository
 
   def new(*args)
-    property_decorator.new(
-      base_repository.new(*args),
-      validations
-    ).run
+    decorate(base_repository.new(*args))
   end
 
   def find(*args)
+    decorate(base_repository.find(*args))
+  end
+
+  def decorate(asset)
     property_decorator.new(
-      base_repository.find(*args),
+      asset,
       validations
     ).run
   end

--- a/app/services/property_validations_generator.rb
+++ b/app/services/property_validations_generator.rb
@@ -1,0 +1,10 @@
+class PropertyValidationsGenerator
+  pattr_initialize :base_repository
+  def validations
+    {
+      :lcsubject => [
+        SubjectCvValidator.new
+      ]
+    }
+  end
+end

--- a/app/validators/base_uri_validator.rb
+++ b/app/validators/base_uri_validator.rb
@@ -6,4 +6,8 @@ class BaseUriValidator
       UriValidator.valid?(value) && value.start_with?(base_uri.to_s)
     end
   end
+
+  def message
+    "is not in the base uri #{base_uri}"
+  end
 end

--- a/app/validators/base_uri_validator.rb
+++ b/app/validators/base_uri_validator.rb
@@ -1,0 +1,9 @@
+class BaseUriValidator
+  pattr_initialize :base_uri
+
+  def valid?(values)
+    Array.wrap(values).all? do |value|
+      UriValidator.valid?(value) && value.start_with?(base_uri.to_s)
+    end
+  end
+end

--- a/app/validators/lcsh_validator.rb
+++ b/app/validators/lcsh_validator.rb
@@ -1,8 +1,6 @@
 class LcshValidator
   def valid?(values)
-    Array.wrap(values).all? do |value|
-      UriValidator.valid?(value) && value.start_with?(base_uri)
-    end
+    validator.valid?(values)
   end
 
   def message
@@ -10,6 +8,10 @@ class LcshValidator
   end
 
   private
+
+  def validator
+    @validator ||= BaseUriValidator.new(base_uri)
+  end
 
   def base_uri
     "http://id.loc.gov/authorities/subjects"

--- a/app/validators/lcsh_validator.rb
+++ b/app/validators/lcsh_validator.rb
@@ -1,0 +1,11 @@
+class LcshValidator
+  def valid?(value)
+    UriValidator.valid?(value) && value.start_with?(base_uri)
+  end
+
+  private
+
+  def base_uri
+    "http://id.loc.gov/authorities/subjects"
+  end
+end

--- a/app/validators/lcsh_validator.rb
+++ b/app/validators/lcsh_validator.rb
@@ -1,6 +1,12 @@
 class LcshValidator
-  def valid?(value)
-    UriValidator.valid?(value) && value.start_with?(base_uri)
+  def valid?(values)
+    Array.wrap(values).all? do |value|
+      UriValidator.valid?(value) && value.start_with?(base_uri)
+    end
+  end
+
+  def message
+    "contains a non-LCSH term"
   end
 
   private

--- a/app/validators/opaque_ns_subject_validator.rb
+++ b/app/validators/opaque_ns_subject_validator.rb
@@ -1,0 +1,19 @@
+class OpaqueNsSubjectValidator
+  def valid?(values)
+    validator.valid?(values)
+  end
+
+  def message
+    "contains a non opaque namespace term"
+  end
+
+  private
+
+  def validator
+    @validator ||= BaseUriValidator.new(base_uri)
+  end
+
+  def base_uri
+    "http://opaquenamespace.org/ns/subject"
+  end
+end

--- a/app/validators/or_validator.rb
+++ b/app/validators/or_validator.rb
@@ -1,0 +1,13 @@
+class OrValidator
+  pattr_initialize :validators
+
+  def valid?(record)
+    validators.any? do |validator|
+      validator.valid?(record)
+    end
+  end
+
+  def message
+    @message ||= validators.map(&:message).to_sentence
+  end
+end

--- a/app/validators/or_validator.rb
+++ b/app/validators/or_validator.rb
@@ -8,6 +8,7 @@ class OrValidator
   end
 
   def message
-    @message ||= validators.map(&:message).to_sentence
+    @message ||= validators.map(&:message).
+      to_sentence(:two_words_connector => " or ", :last_word_connector => ", or ")
   end
 end

--- a/app/validators/subject_cv_validator.rb
+++ b/app/validators/subject_cv_validator.rb
@@ -13,7 +13,8 @@ class SubjectCvValidator
   def validators
     [
       LcshValidator.new,
-      OpaqueNsSubjectValidator.new
+      OpaqueNsSubjectValidator.new,
+      BaseUriValidator.new("http://vocab.getty.edu/tgn/")
     ]
   end
 end

--- a/app/validators/subject_cv_validator.rb
+++ b/app/validators/subject_cv_validator.rb
@@ -1,0 +1,19 @@
+class SubjectCvValidator
+  delegate :message, :to => :or_validator
+  def valid?(value)
+    or_validator.valid?(value)
+  end
+
+  private
+
+  def or_validator
+    @or_validator ||= OrValidator.new(validators)
+  end
+
+  def validators
+    [
+      LcshValidator.new,
+      OpaqueNsSubjectValidator.new
+    ]
+  end
+end

--- a/app/validators/uri_validator.rb
+++ b/app/validators/uri_validator.rb
@@ -1,0 +1,7 @@
+class UriValidator
+  class << self
+    def valid?(value)
+      value.instance_of?(RDF::URI)
+    end
+  end
+end

--- a/spec/decorators/decorate_properties_spec.rb
+++ b/spec/decorators/decorate_properties_spec.rb
@@ -1,0 +1,35 @@
+require 'rails_helper'
+
+RSpec.describe DecorateProperties do
+  subject { DecorateProperties.new(resource, property_mapper) }
+  let(:resource) { object_double(GenericAsset.new) }
+  let(:property_mapper) do
+    {
+      :title => [
+        validator,
+        validator2
+      ]
+    }
+  end
+  let(:validator) { fake_validator(true) }
+  let(:validator2) { fake_validator(true) }
+
+  describe "#run" do
+    before do
+      allow(WithValidatedProperty).to receive(:new).and_call_original
+    end
+    it "should decorate the given properties" do
+      result = subject.run
+
+      expect(WithValidatedProperty).to have_received(:new).with(resource, :title, validator)
+      expect(WithValidatedProperty).to have_received(:new).with(result.__getobj__, :title, validator2)
+    end
+  end
+
+  def fake_validator(result=true)
+    v = double("Validator")
+    allow(v).to receive(:valid?).with(resource).and_return(result)
+    allow(v).to receive(:message).and_return("has a bad validation")
+    v
+  end
+end

--- a/spec/decorators/with_validated_property_spec.rb
+++ b/spec/decorators/with_validated_property_spec.rb
@@ -1,0 +1,45 @@
+require 'rails_helper'
+
+RSpec.describe WithValidatedProperty do
+  subject { WithValidatedProperty.new(asset, property, validator) }
+  let(:asset) { object_double(GenericAsset.new) }
+  let(:property) { :title }
+  let(:validator) { double("Validator") }
+  let(:result) { double("result") }
+  let(:errors) { ActiveModel::Errors.new(result) }
+  before do
+    allow(asset).to receive(:get_values).with(property, :cast => false).and_return(result)
+    allow(asset).to receive(:errors).and_return(errors)
+    allow(asset).to receive(:valid?).and_return(true)
+    allow(errors).to receive(:add).and_call_original
+    allow(validator).to receive(:message).and_return("is so awful")
+  end
+
+  describe "#valid?" do
+    let(:valid) { true }
+    before do
+      allow(validator).to receive(:valid?).with(result).and_return(valid)
+      subject.valid?
+    end
+    it "should call asset.valid?" do
+      expect(asset).to have_received(:valid?)
+    end
+    context "when validator returns true" do
+      it "should not add any errors" do
+        expect(errors).not_to have_received(:add)
+      end
+      it "should return true" do
+        expect(subject.valid?).to eq true
+      end
+    end
+    context "when validator returns false" do
+      let(:valid) { false }
+      it "should add an error" do
+        expect(errors).to have_received(:add).with(property, "is so awful")
+      end
+      it "should return false" do
+        expect(subject.valid?).to eq false
+      end
+    end
+  end
+end

--- a/spec/repositories/validated_asset_repository_spec.rb
+++ b/spec/repositories/validated_asset_repository_spec.rb
@@ -32,6 +32,15 @@ RSpec.describe ValidatedAssetRepository do
     end
   end
 
+  describe "#decorate" do
+    let(:image) { Image.new }
+    let(:result) { subject.decorate(image) }
+    it "should decorate the asset passed" do
+      expect(result.class).to eq WithValidatedProperty
+      expect(result.__getobj__).to eq image
+    end
+  end
+
   describe "#find" do
     context "when given an existing asset" do
       let(:image) do

--- a/spec/repositories/validated_asset_repository_spec.rb
+++ b/spec/repositories/validated_asset_repository_spec.rb
@@ -1,0 +1,47 @@
+require 'rails_helper'
+
+RSpec.describe ValidatedAssetRepository do
+  subject { ValidatedAssetRepository.new(Image) }
+
+  describe "#new" do
+    let(:image) { Image.new }
+    before do
+      allow(Image).to receive(:new).and_return(image)
+      allow(image).to receive(:create_or_update).and_return(true)
+    end
+    let(:result) { subject.new }
+    it "should validate it" do
+      result.lcsubject = ["bla"]
+
+      expect(result).not_to be_valid
+    end
+    it "should not be able to save it with a bad subject" do
+      result.lcsubject = ["bla"]
+
+      expect(result.save).to eq false
+    end
+    it "should be able to save it with a good subject" do
+      result.lcsubject = [RDF::URI("http://id.loc.gov/authorities/subjects/1")]
+
+      expect(result.save).to eq true
+    end
+  end
+
+  describe "#find" do
+    context "when given an existing asset" do
+      let(:image) do
+        Image.new do |i|
+          allow(i).to receive(:id).and_return("1")
+          i.lcsubject = ["bla"]
+        end
+      end
+      let(:result) { subject.find(image.id) }
+      before do
+        allow(Image).to receive(:find).with("1").and_return(image)
+      end
+      it "should validate it" do
+        expect(result).not_to be_valid
+      end
+    end
+  end
+end

--- a/spec/repositories/validated_asset_repository_spec.rb
+++ b/spec/repositories/validated_asset_repository_spec.rb
@@ -25,6 +25,11 @@ RSpec.describe ValidatedAssetRepository do
 
       expect(result.save).to eq true
     end
+    it "should validate from multiple sources" do
+      result.lcsubject = [RDF::URI("http://opaquenamespace.org/ns/subject/banana")]
+
+      expect(result).to be_valid
+    end
   end
 
   describe "#find" do

--- a/spec/validators/base_uri_validator_spec.rb
+++ b/spec/validators/base_uri_validator_spec.rb
@@ -1,0 +1,26 @@
+require 'rails_helper'
+
+RSpec.describe BaseUriValidator do
+  subject { BaseUriValidator.new("http://opaquenamespace.org/ns/subject") }
+  describe "#valid?" do
+    let(:result) { subject.valid?(value) }
+    context 'when given a bad uri' do
+      let(:value) { [RDF::URI("http://bla.org/bla")] }
+      it "should return false" do
+        expect(result).to eq false
+      end
+    end
+    context "when given an good uri" do
+      let(:value) { [RDF::URI("http://opaquenamespace.org/ns/subject/1")] }
+      it "should return true" do
+        expect(result).to eq true
+      end
+    end
+    context "when given a string and not a URI" do
+      let(:value) { ["http://opaquenamespace.org/ns/subject/1"] }
+      it "should return false" do
+        expect(result).to eq false
+      end
+    end
+  end
+end

--- a/spec/validators/base_uri_validator_spec.rb
+++ b/spec/validators/base_uri_validator_spec.rb
@@ -23,4 +23,10 @@ RSpec.describe BaseUriValidator do
       end
     end
   end
+
+  describe "#message" do
+    it "should be right" do
+      expect(subject.message).to eq "is not in the base uri http://opaquenamespace.org/ns/subject"
+    end
+  end
 end

--- a/spec/validators/lcsh_validator_spec.rb
+++ b/spec/validators/lcsh_validator_spec.rb
@@ -1,0 +1,26 @@
+require 'rails_helper'
+
+RSpec.describe LcshValidator do
+  subject { LcshValidator.new }
+  describe "#valid?" do
+    let(:result) { subject.valid?(value) }
+    context 'when given a non-lcsh uri' do
+      let(:value) { RDF::URI("http://opaquenamespace.org/ns/subject/bad") }
+      it "should return false" do
+        expect(result).to eq false
+      end
+    end
+    context "when given an lcsh uri" do
+      let(:value) { RDF::URI("http://id.loc.gov/authorities/subjects/1") }
+      it "should return true" do
+        expect(result).to eq true
+      end
+    end
+    context "when given a string and not a URI" do
+      let(:value) { "http://id.loc.gov/authorities/subjects/1" }
+      it "should return false" do
+        expect(result).to eq false
+      end
+    end
+  end
+end

--- a/spec/validators/lcsh_validator_spec.rb
+++ b/spec/validators/lcsh_validator_spec.rb
@@ -5,22 +5,28 @@ RSpec.describe LcshValidator do
   describe "#valid?" do
     let(:result) { subject.valid?(value) }
     context 'when given a non-lcsh uri' do
-      let(:value) { RDF::URI("http://opaquenamespace.org/ns/subject/bad") }
+      let(:value) { [RDF::URI("http://opaquenamespace.org/ns/subject/bad")] }
       it "should return false" do
         expect(result).to eq false
       end
     end
     context "when given an lcsh uri" do
-      let(:value) { RDF::URI("http://id.loc.gov/authorities/subjects/1") }
+      let(:value) { [RDF::URI("http://id.loc.gov/authorities/subjects/1")] }
       it "should return true" do
         expect(result).to eq true
       end
     end
     context "when given a string and not a URI" do
-      let(:value) { "http://id.loc.gov/authorities/subjects/1" }
+      let(:value) { ["http://id.loc.gov/authorities/subjects/1"] }
       it "should return false" do
         expect(result).to eq false
       end
+    end
+  end
+
+  describe "#message" do
+    it "should be right" do
+      expect(subject.message).to eq "contains a non-LCSH term"
     end
   end
 end

--- a/spec/validators/lcsh_validator_spec.rb
+++ b/spec/validators/lcsh_validator_spec.rb
@@ -3,24 +3,18 @@ require 'rails_helper'
 RSpec.describe LcshValidator do
   subject { LcshValidator.new }
   describe "#valid?" do
-    let(:result) { subject.valid?(value) }
-    context 'when given a non-lcsh uri' do
-      let(:value) { [RDF::URI("http://opaquenamespace.org/ns/subject/bad")] }
-      it "should return false" do
-        expect(result).to eq false
-      end
-    end
-    context "when given an lcsh uri" do
-      let(:value) { [RDF::URI("http://id.loc.gov/authorities/subjects/1")] }
-      it "should return true" do
-        expect(result).to eq true
-      end
-    end
-    context "when given a string and not a URI" do
-      let(:value) { ["http://id.loc.gov/authorities/subjects/1"] }
-      it "should return false" do
-        expect(result).to eq false
-      end
+    let(:base_uri) { "http://id.loc.gov/authorities/subjects" }
+    let(:validator) { instance_double(BaseUriValidator) }
+    let(:value) { ["#{base_uri}/1"] }
+    it "should ask BaseUriValidator" do
+      allow(BaseUriValidator).to receive(:new).with(base_uri).and_return(validator)
+      validation_result = double("Result")
+      allow(validator).to receive(:valid?).and_return(validation_result)
+
+      result = subject.valid?(value)
+
+      expect(validator).to have_received(:valid?).with(value)
+      expect(result).to eq validation_result
     end
   end
 

--- a/spec/validators/opaque_ns_subject_validator_spec.rb
+++ b/spec/validators/opaque_ns_subject_validator_spec.rb
@@ -1,0 +1,26 @@
+require 'rails_helper'
+
+RSpec.describe OpaqueNsSubjectValidator do
+  subject { described_class.new }
+  describe "#valid?" do
+    let(:base_uri) { "http://opaquenamespace.org/ns/subject" }
+    let(:validator) { instance_double(BaseUriValidator) }
+    let(:value) { ["#{base_uri}/1"] }
+    it "should ask BaseUriValidator" do
+      allow(BaseUriValidator).to receive(:new).with(base_uri).and_return(validator)
+      validation_result = double("Result")
+      allow(validator).to receive(:valid?).and_return(validation_result)
+
+      result = subject.valid?(value)
+
+      expect(validator).to have_received(:valid?).with(value)
+      expect(result).to eq validation_result
+    end
+  end
+
+  describe "#message" do
+    it "should be right" do
+      expect(subject.message).to eq "contains a non opaque namespace term"
+    end
+  end
+end

--- a/spec/validators/or_validator_spec.rb
+++ b/spec/validators/or_validator_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe OrValidator do
     end
     describe "#message" do
       it "should combine the two validators' messages" do
-        expect(subject.message).to eq "message and message"
+        expect(subject.message).to eq "message or message"
       end
     end
   end

--- a/spec/validators/or_validator_spec.rb
+++ b/spec/validators/or_validator_spec.rb
@@ -1,0 +1,43 @@
+require 'rails_helper'
+
+RSpec.describe OrValidator do
+  subject { described_class.new(validators) }
+  let(:validators) { [ validator_1, validator_2 ] }
+  let(:validator_1) { mock_validator(valid: true) }
+  let(:validator_2) { mock_validator(valid: true) }
+
+  describe "#valid?" do
+    let(:value) { double("value") }
+    let(:result) { subject.valid?(value) }
+    context "when both validators are valid" do
+      it "should return true" do
+        expect(result).to eq true
+      end
+    end
+    context "when one is valid" do
+      let(:validator_2) { mock_validator(valid: false) }
+      it "should return true" do
+        expect(result).to eq true
+      end
+    end
+    context "when both are invalid" do
+      let(:validator_1) { mock_validator(valid: false) }
+      let(:validator_2) { mock_validator(valid: false) }
+      it "should return false" do
+        expect(result).to eq false
+      end
+    end
+    describe "#message" do
+      it "should combine the two validators' messages" do
+        expect(subject.message).to eq "message and message"
+      end
+    end
+  end
+
+  def mock_validator(valid:)
+    i = instance_double(BaseUriValidator)
+    allow(i).to receive(:valid?).and_return(valid)
+    allow(i).to receive(:message).and_return("message")
+    i
+  end
+end

--- a/spec/validators/subject_cv_validator_spec.rb
+++ b/spec/validators/subject_cv_validator_spec.rb
@@ -1,0 +1,33 @@
+require 'rails_helper'
+
+RSpec.describe SubjectCvValidator do
+  subject { described_class.new }
+
+  describe "#valid?" do
+    let(:result) { subject.valid?(value) }
+    context "when given a string" do
+      let(:value) { "string" }
+      it "should not be valid" do
+        expect(result).to eq false
+      end
+    end
+    context "when given an OpaqueNamespace URI" do
+      let(:value) { RDF::URI("http://opaquenamespace.org/ns/subject/1") }
+      it "should be valid" do
+        expect(result).to eq true
+      end
+    end
+    context "when given an LCSH URI" do
+      let(:value) { RDF::URI("http://id.loc.gov/authorities/subjects/1") }
+      it "should be valid" do
+        expect(result).to eq true
+      end
+    end
+  end
+
+  describe "#message" do
+    it "should be a combination of validators strings" do
+      expect(subject.message).to eq subject.__send__(:validators).map(&:message).to_sentence
+    end
+  end
+end

--- a/spec/validators/subject_cv_validator_spec.rb
+++ b/spec/validators/subject_cv_validator_spec.rb
@@ -23,5 +23,11 @@ RSpec.describe SubjectCvValidator do
         expect(result).to eq true
       end
     end
+    context "when given a Getty URI" do
+      let(:value) { RDF::URI("http://vocab.getty.edu/tgn/1") }
+      it "should be valid" do
+        expect(result).to eq true
+      end
+    end
   end
 end

--- a/spec/validators/subject_cv_validator_spec.rb
+++ b/spec/validators/subject_cv_validator_spec.rb
@@ -24,10 +24,4 @@ RSpec.describe SubjectCvValidator do
       end
     end
   end
-
-  describe "#message" do
-    it "should be a combination of validators strings" do
-      expect(subject.message).to eq subject.__send__(:validators).map(&:message).to_sentence
-    end
-  end
 end


### PR DESCRIPTION
This is effectively conditional decoration of validators on objects, and a few validators for Getty/LCSH/Opaque Namespace subjects. If you spin up an object via
```ruby
g = ValidatedAssetRepository.new(GenericAsset).new
```

then you'll get an asset which can't be saved without passing controlled vocab validations.

This infrastructure should give us a clean way to abstract out how validators are generated at a later date.

Closes #18, closes #19, and closes #20.