### PR TITLE
Use #__send__ to access property.

### DIFF
--- a/app/decorators/with_validated_property.rb
+++ b/app/decorators/with_validated_property.rb
@@ -2,14 +2,14 @@ class WithValidatedProperty < SimpleDelegator
   attr_reader :property, :validator
   def initialize(resource, property, validator)
     super(resource)
-    @property = property
+    @property = ValidatedProperty(property)
     @validator = validator
   end
 
   def valid?(*args)
     __getobj__.valid?(*args)
     unless validator.valid?(result)
-      errors.add(property, validator.message)
+      errors.add(property.validated_property, validator.message)
     end
     errors.blank?
   end
@@ -22,6 +22,6 @@ class WithValidatedProperty < SimpleDelegator
   private
 
   def result
-    get_values(property, :cast => false)
+    __send__(property.property_accessor)
   end
 end

--- a/app/services/property_validations_generator.rb
+++ b/app/services/property_validations_generator.rb
@@ -2,9 +2,17 @@ class PropertyValidationsGenerator
   pattr_initialize :base_repository
   def validations
     {
-      :lcsubject => [
+      validated_property(:lcsubject) => [
         SubjectCvValidator.new
       ]
     }
+  end
+
+  private
+
+  # We need to validate against the URIs, not the AT objects, so access with
+  # :lcsubject_ids, but add errors to :lcsubject.
+  def validated_property(property)
+    ValidatedProperty.new(property, "#{property}_ids".to_sym)
   end
 end

--- a/app/values/validated_property.rb
+++ b/app/values/validated_property.rb
@@ -1,0 +1,13 @@
+class ValidatedProperty
+  vattr_initialize :validated_property, :property_accessor
+end
+
+module Kernel
+  def ValidatedProperty(value)
+    if value.kind_of? ValidatedProperty
+      value
+    else
+      ValidatedProperty.new(value.to_sym, value.to_sym)
+    end
+  end
+end

--- a/spec/decorators/with_validated_property_spec.rb
+++ b/spec/decorators/with_validated_property_spec.rb
@@ -9,7 +9,6 @@ RSpec.describe WithValidatedProperty do
   let(:errors) { ActiveModel::Errors.new(result) }
   before do
     allow(asset).to receive(:title).and_return(result)
-    #allow(asset).to receive(:get_values).with(property, :cast => false).and_return(result)
     allow(asset).to receive(:errors).and_return(errors)
     allow(asset).to receive(:valid?).and_return(true)
     allow(errors).to receive(:add).and_call_original

--- a/spec/decorators/with_validated_property_spec.rb
+++ b/spec/decorators/with_validated_property_spec.rb
@@ -8,7 +8,8 @@ RSpec.describe WithValidatedProperty do
   let(:result) { double("result") }
   let(:errors) { ActiveModel::Errors.new(result) }
   before do
-    allow(asset).to receive(:get_values).with(property, :cast => false).and_return(result)
+    allow(asset).to receive(:title).and_return(result)
+    #allow(asset).to receive(:get_values).with(property, :cast => false).and_return(result)
     allow(asset).to receive(:errors).and_return(errors)
     allow(asset).to receive(:valid?).and_return(true)
     allow(errors).to receive(:add).and_call_original

--- a/spec/values/validated_property_spec.rb
+++ b/spec/values/validated_property_spec.rb
@@ -1,0 +1,32 @@
+require 'rails_helper'
+
+RSpec.describe ValidatedProperty do
+  subject { ValidatedProperty.new(:validated_property, :property_accessor) }
+  describe "#validated_property" do
+    it "should return the validated property" do
+      expect(subject.validated_property).to eq :validated_property
+    end
+  end
+  describe "#property_accessor" do
+    it "should return the property accessor" do
+      expect(subject.property_accessor).to eq :property_accessor
+    end
+  end
+
+  describe "Caster" do
+    subject { ValidatedProperty(value) }
+    context "when given a string" do
+      let(:value) { "test" }
+      it "should return with both attributes set to its symbol" do
+        expect(subject.validated_property).to eq :test
+        expect(subject.property_accessor).to eq :test
+      end
+    end
+    context "when given a validated property" do
+      let(:value) { ValidatedProperty.new(:test, :test2) }
+      it "should return it back" do
+        expect(subject).to eq value
+      end
+    end
+  end
+end


### PR DESCRIPTION
This separates which property is used to access vs add errors to, so that we
don't have to use ActiveTriple's weird get_values API.