### PR TITLE
Fix bug when looking up non-NOID ids

### DIFF
--- a/app/models/generic_asset.rb
+++ b/app/models/generic_asset.rb
@@ -14,6 +14,6 @@ class GenericAsset < ActiveFedora::Base
   private
 
   def assign_id
-    injector.id_service.mint
+    injector.id_service.mint.reverse
   end
 end

--- a/config/initializers/noid.rb
+++ b/config/initializers/noid.rb
@@ -3,4 +3,5 @@ require 'active_fedora/noid'
 ActiveFedora::Noid.configure do |config|
   config.statefile = ENV['NOID_STATEFILE'] || Rails.root.join("tmp", "minter-state-#{Rails.env}")
   config.template = '.reeddeeddk'
+  config.treeifier = ->(id) { id }
 end

--- a/spec/models/files/yml_file_spec.rb
+++ b/spec/models/files/yml_file_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Files::YmlFile do
     @content = File.read(File.join(fixture_path, "fixture_yml.yml"))
   end
   before(:each) do
-    class DummyAsset < GenericAsset
+    class DummyAsset < ActiveFedora::Base
       contains 'descMetadata', :class_name => 'Files::YmlFile'
     end
   end

--- a/spec/models/generic_asset_spec.rb
+++ b/spec/models/generic_asset_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe GenericAsset do
       let(:id_service) { instance_double("ActiveFedora::Noid::Service") }
       before(:each) do
         allow(OregonDigital.inject).to receive(:id_service).and_return(id_service)
-        allow(id_service).to receive(:mint).and_return("9999")
+        allow(id_service).to receive(:mint).and_return("987654321")
       end
       context "when it doesn't have an id" do
         before do
@@ -62,6 +62,9 @@ RSpec.describe GenericAsset do
         end
         it 'should no longer be nil' do
           expect(generic_asset.id).not_to be_nil
+        end
+        it 'should reverse the id for better bucketing' do
+          expect(generic_asset.id).to eq('123456789')
         end
       end
       context 'but it already has an id' do


### PR DESCRIPTION
- Subclasses DummyAsset from ActiveFedora::Base again
- Overrides treeifier to just return id as-is
- reverses the minted noid so bucketing is distributed even with no
  treeify magic
- Tests reversal of noid

Fixes #54 