### PR TITLE
Fix rake task for generating a user admin

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,3 +32,9 @@ You can go to your browser and open `http://localhost:3000`, where you can see t
 Run tests with RSpec:
 
     rspec spec
+
+Set up a dev admin user:
+
+    rake admin_user
+
+Log in to the app as "admin@example.org" with password "admin123".

--- a/lib/tasks/admin_user.rake
+++ b/lib/tasks/admin_user.rake
@@ -1,7 +1,13 @@
 desc 'Create an admin user and roles for development environment'
 
 task :admin_user => :environment do |t, args|
-  u = User.new({:email => "admin@example.org", :password => "admin123", :password_confirmation => "admin123" })
-  u.save
+  user = User.find_or_create_by(:email => "admin@example.org") do |u|
+    u.password = "admin123"
+    u.password_confirmation = "admin123"
+  end
+
+  admin = Role.find_or_create_by(:name => "admin")
+  user.roles = [admin]
+  user.save!
 end
 


### PR DESCRIPTION
Ensures admin@example.org is created or updated to be the admin