### PR TITLE
Feature/hint logic

### DIFF
--- a/app/decorators/has_hint_option.rb
+++ b/app/decorators/has_hint_option.rb
@@ -4,6 +4,6 @@ class HasHintOption < SimpleDelegator
   end
 
   def hint
-    nil
+    object.model.validators[property].map(&:message)[0] unless object.model.validators[property].nil?
   end
 end

--- a/app/decorators/has_hint_option.rb
+++ b/app/decorators/has_hint_option.rb
@@ -4,6 +4,12 @@ class HasHintOption < SimpleDelegator
   end
 
   def hint
-    object.model.validators[property].map(&:message)[0] unless object.model.validators[property].nil?
+    "Must fulfill: #{hint_message}" if hint_message
+  end
+
+  private
+
+  def hint_message
+    Array(object.validators[property]).map(&:message)[0]
   end
 end

--- a/app/decorators/has_hint_option.rb
+++ b/app/decorators/has_hint_option.rb
@@ -10,6 +10,6 @@ class HasHintOption < SimpleDelegator
   private
 
   def hint_message
-    object.property_hint(property).join(", ")
+    object.property_hint(property)
   end
 end

--- a/app/decorators/has_hint_option.rb
+++ b/app/decorators/has_hint_option.rb
@@ -4,12 +4,12 @@ class HasHintOption < SimpleDelegator
   end
 
   def hint
-    "Must fulfill: #{hint_message.join(", ")}" unless hint_message.empty?
+    "Must fulfill: #{hint_message}" unless hint_message.empty?
   end
 
   private
 
   def hint_message
-    object.property_hint(property)
+    object.property_hint(property).join(", ")
   end
 end

--- a/app/decorators/has_hint_option.rb
+++ b/app/decorators/has_hint_option.rb
@@ -4,12 +4,12 @@ class HasHintOption < SimpleDelegator
   end
 
   def hint
-    "Must fulfill: #{hint_message}" if hint_message
+    "Must fulfill: #{hint_message.join(", ")}" unless hint_message.empty?
   end
 
   private
 
   def hint_message
-    Array(object.validators[property]).map(&:message)[0]
+    object.property_hint(property)
   end
 end

--- a/app/forms/generic_asset_form.rb
+++ b/app/forms/generic_asset_form.rb
@@ -11,7 +11,7 @@ class GenericAssetForm
   end
 
   def property_hint(property)
-    Array.wrap(validators[property]).map(&:message).compact
+    Array.wrap(validators[property]).map(&:message).compact.to_sentence
   end
 
 end

--- a/app/forms/generic_asset_form.rb
+++ b/app/forms/generic_asset_form.rb
@@ -9,4 +9,9 @@ class GenericAssetForm
   def self.permitted_params
     super << :content
   end
+
+  def property_hint(property)
+    Array.wrap(validators[property]).map(&:message).compact
+  end
+
 end

--- a/app/forms/generic_asset_form.rb
+++ b/app/forms/generic_asset_form.rb
@@ -1,5 +1,6 @@
 class GenericAssetForm
   include HydraEditor::Form
+  delegate :validators, :to => :model
   # TODO: Put :workType back in once our editor can support URLs and/or we have
   # a "clean" graph from AF
   skip_terms = [:workType]

--- a/app/forms/oregon_digital/fields/input_factory.rb
+++ b/app/forms/oregon_digital/fields/input_factory.rb
@@ -1,26 +1,18 @@
 module OregonDigital
   module Fields
     class InputFactory
-      class << self
-        def create(object, property)
-          decorate do
-            base_factory.create(object, property)
-          end
-        end
+      pattr_initialize :base_factory, :decorator
 
-        private
-
-        def decorate
-          decorator.new(yield)
+      def create(object, property)
+        decorate do
+          base_factory.create(object, property)
         end
+      end
 
-        def decorator
-          HasHintOption
-        end
+      private
 
-        def base_factory
-          HydraEditor::Fields::Factory
-        end
+      def decorate
+        decorator.new(yield)
       end
     end
   end

--- a/app/models/generic_asset.rb
+++ b/app/models/generic_asset.rb
@@ -21,4 +21,5 @@ class GenericAsset < ActiveFedora::Base
   def assign_id
     injector.id_service.mint.reverse
   end
+
 end

--- a/config/initializers/hydra_editor.rb
+++ b/config/initializers/hydra_editor.rb
@@ -1,2 +1,2 @@
 HydraEditor.models = ["Image", "Document"]
-HydraEditor::Fields::Generator.factory = OregonDigital::Fields::InputFactory 
+HydraEditor::Fields::Generator.factory = OregonDigital::Fields::InputFactory.new(HydraEditor::Fields::Factory, HasHintOption)

--- a/spec/decorators/has_hint_option_spec.rb
+++ b/spec/decorators/has_hint_option_spec.rb
@@ -6,16 +6,12 @@ RSpec.describe HasHintOption do
   let(:base_input) { instance_double(HydraEditor::Fields::Input) }
   let(:validators) { {} }
   let(:property) { :lcsubject }
-  let(:nil_message) {[nil].compact}
-  let(:validator_message) {["Here is a message"]}
-  let(:validator_messages) {["Here is a message", "another"]}
- 
 
   describe "#hint" do
     before do
       allow(base_input).to receive(:object).and_return(object)
       allow(base_input).to receive(:property).and_return(property) 
-      allow(object).to receive(:property_hint).and_return(nil_message)
+      allow(object).to receive(:property_hint).and_return("")
     end
 
     context "when there are no messages to return" do
@@ -25,20 +21,11 @@ RSpec.describe HasHintOption do
     end
     context "when there is a validator" do
       before do
-        allow(object).to receive(:property_hint).and_return(validator_message.to_sentence) 
+        allow(object).to receive(:property_hint).and_return("Here is a message") 
       end
       
       it "should return that validator's message" do
         expect(subject.hint).to eq "Must fulfill: Here is a message"
-      end
-      context "With multiple validator messages" do
-        before do
-          allow(object).to receive(:property_hint).and_return(validator_messages.to_sentence) 
-        end
-
-        it "should return those messages comma delimited" do
-          expect(subject.hint).to eq"Must fulfill: Here is a message and another"
-        end
       end
     end
   end

--- a/spec/decorators/has_hint_option_spec.rb
+++ b/spec/decorators/has_hint_option_spec.rb
@@ -1,0 +1,48 @@
+require 'rails_helper'
+
+RSpec.describe HasHintOption do
+  subject { described_class.new(base_input) }
+  let(:object) { build_object }
+  let(:base_input) { build_base_input }
+  let(:validators) { {} }
+  let(:property) { :lcsubject }
+
+  describe "#hint" do
+    context "when there is no validator" do
+      it "should return nil" do
+        expect(subject.hint).to eq nil
+      end
+    end
+    context "when there is a validator" do
+      let(:validators) do
+        {
+          property => [validator]
+        }
+      end
+      let(:validator) { build_validator }
+
+      it "should return that validator's message" do
+        expect(subject.hint).to eq "Must fulfill: be awesome"
+      end
+    end
+  end
+
+  def build_validator
+    instance_double(SubjectCvValidator).tap do |f|
+      allow(f).to receive(:message).and_return("be awesome")
+    end
+  end
+
+  def build_base_input
+    instance_double(HydraEditor::Fields::Input).tap do |f|
+      allow(f).to receive(:object).and_return(object)
+      allow(f).to receive(:property).and_return(property)
+    end
+  end
+
+  def build_object
+    instance_double(GenericAssetForm).tap do |f|
+      allow(f).to receive(:validators).and_return(validators)
+    end
+  end
+end

--- a/spec/decorators/has_hint_option_spec.rb
+++ b/spec/decorators/has_hint_option_spec.rb
@@ -6,29 +6,39 @@ RSpec.describe HasHintOption do
   let(:base_input) { instance_double(HydraEditor::Fields::Input) }
   let(:validators) { {} }
   let(:property) { :lcsubject }
+  let(:nil_message) {[nil].compact}
+  let(:validator_message) {["Here is a message"]}
+  let(:validator_messages) {["Here is a message", "and another"]}
+ 
 
   describe "#hint" do
     before do
-        allow(base_input).to receive(:object).and_return(object)
-        allow(base_input).to receive(:property).and_return(property)
-        allow(object).to receive(:validators).and_return(validators)
+      allow(base_input).to receive(:object).and_return(object)
+      allow(base_input).to receive(:property).and_return(property) 
+      allow(object).to receive(:property_hint).and_return(nil_message)
     end
-    context "when there is no validator" do
+
+    context "when there are no messages to return" do
       it "should return nil" do
         expect(subject.hint).to eq nil
       end
     end
     context "when there is a validator" do
-      let(:validator) { instance_double(SubjectCvValidator) }
-      let(:validators) do
-        {
-          property => [validator]
-        }
+      before do
+        allow(object).to receive(:property_hint).and_return(validator_message) 
       end
+      
       it "should return that validator's message" do
-        allow(validator).to receive(:message).and_return("be awesome")
+        expect(subject.hint).to eq "Must fulfill: Here is a message"
+      end
+      context "With multiple validator messages" do
+        before do
+          allow(object).to receive(:property_hint).and_return(validator_messages) 
+        end
 
-        expect(subject.hint).to eq "Must fulfill: be awesome"
+        it "should return those messages comma delimited" do
+          expect(subject.hint).to eq"Must fulfill: Here is a message, and another"
+        end
       end
     end
   end

--- a/spec/decorators/has_hint_option_spec.rb
+++ b/spec/decorators/has_hint_option_spec.rb
@@ -2,47 +2,34 @@ require 'rails_helper'
 
 RSpec.describe HasHintOption do
   subject { described_class.new(base_input) }
-  let(:object) { build_object }
-  let(:base_input) { build_base_input }
+  let(:object) { instance_double(GenericAssetForm) }
+  let(:base_input) { instance_double(HydraEditor::Fields::Input) }
   let(:validators) { {} }
   let(:property) { :lcsubject }
 
   describe "#hint" do
+    before do
+        allow(base_input).to receive(:object).and_return(object)
+        allow(base_input).to receive(:property).and_return(property)
+        allow(object).to receive(:validators).and_return(validators)
+    end
     context "when there is no validator" do
       it "should return nil" do
         expect(subject.hint).to eq nil
       end
     end
     context "when there is a validator" do
+      let(:validator) { instance_double(SubjectCvValidator) }
       let(:validators) do
         {
           property => [validator]
         }
       end
-      let(:validator) { build_validator }
-
       it "should return that validator's message" do
+        allow(validator).to receive(:message).and_return("be awesome")
+
         expect(subject.hint).to eq "Must fulfill: be awesome"
       end
-    end
-  end
-
-  def build_validator
-    instance_double(SubjectCvValidator).tap do |f|
-      allow(f).to receive(:message).and_return("be awesome")
-    end
-  end
-
-  def build_base_input
-    instance_double(HydraEditor::Fields::Input).tap do |f|
-      allow(f).to receive(:object).and_return(object)
-      allow(f).to receive(:property).and_return(property)
-    end
-  end
-
-  def build_object
-    instance_double(GenericAssetForm).tap do |f|
-      allow(f).to receive(:validators).and_return(validators)
     end
   end
 end

--- a/spec/decorators/has_hint_option_spec.rb
+++ b/spec/decorators/has_hint_option_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe HasHintOption do
   let(:property) { :lcsubject }
   let(:nil_message) {[nil].compact}
   let(:validator_message) {["Here is a message"]}
-  let(:validator_messages) {["Here is a message", "and another"]}
+  let(:validator_messages) {["Here is a message", "another"]}
  
 
   describe "#hint" do
@@ -25,7 +25,7 @@ RSpec.describe HasHintOption do
     end
     context "when there is a validator" do
       before do
-        allow(object).to receive(:property_hint).and_return(validator_message) 
+        allow(object).to receive(:property_hint).and_return(validator_message.to_sentence) 
       end
       
       it "should return that validator's message" do
@@ -33,11 +33,11 @@ RSpec.describe HasHintOption do
       end
       context "With multiple validator messages" do
         before do
-          allow(object).to receive(:property_hint).and_return(validator_messages) 
+          allow(object).to receive(:property_hint).and_return(validator_messages.to_sentence) 
         end
 
         it "should return those messages comma delimited" do
-          expect(subject.hint).to eq"Must fulfill: Here is a message, and another"
+          expect(subject.hint).to eq"Must fulfill: Here is a message and another"
         end
       end
     end

--- a/spec/forms/generic_asset_form_spec.rb
+++ b/spec/forms/generic_asset_form_spec.rb
@@ -1,0 +1,17 @@
+require 'rails_helper' 
+
+RSpec.describe GenericAssetForm do
+  let(:generic_form){ instance_double(described_class) }
+  let(:property) { :lcsubject }
+  let(:message) { "This is my message" }
+
+  context "#property_hint" do
+    before do
+      allow(generic_form).to receive(:property_hint).with(property).and_return(message)
+    end
+
+    it "should return a string hint composed of validation messages" do
+      expect(generic_form.property_hint(property)).to eq "This is my message"
+    end
+  end
+end

--- a/spec/forms/generic_asset_form_spec.rb
+++ b/spec/forms/generic_asset_form_spec.rb
@@ -1,17 +1,28 @@
 require 'rails_helper' 
 
-RSpec.describe GenericAssetForm do
-  let(:generic_form){ instance_double(described_class) }
+RSpec.describe ImageForm do
+  let(:generic_form){ described_class.new(image) }
+  let(:image) {object_double(ValidatedAssetRepository.new(Image).new)}
   let(:property) { :lcsubject }
-  let(:message) { "This is my message" }
+  let(:attribute_list) { {property.to_s=> []} }
+  let(:validator) { instance_double(SubjectCvValidator) }
+  let(:validators) { {property => [validator]} }
 
   context "#property_hint" do
     before do
-      allow(generic_form).to receive(:property_hint).with(property).and_return(message)
+      allow(image).to receive(:validators).and_return(validators)
+      allow(image).to receive(:attributes).and_return(attribute_list)
+      allow(validator).to receive(:message).and_return("This is my message")
     end
-
     it "should return a string hint composed of validation messages" do
       expect(generic_form.property_hint(property)).to eq "This is my message"
+    end
+    context "when given multiple validators" do
+      let(:validator_2) { instance_double(SubjectCvValidator, :message => "Message 2") }
+      let(:validators) { {property => [validator, validator_2] } }
+      it "should join both messages" do
+        expect(generic_form.property_hint(property)).to eq "This is my message and Message 2"
+      end
     end
   end
 end

--- a/spec/forms/oregon_digital/fields/input_factory_spec.rb
+++ b/spec/forms/oregon_digital/fields/input_factory_spec.rb
@@ -1,12 +1,36 @@
 require 'rails_helper'
 
 RSpec.describe OregonDigital::Fields::InputFactory do
+  subject { described_class.new(base_factory, decorator) }
+  let(:base_factory) { build_input_factory }
+  let(:decorator) { build_decorator }
+  let(:decorated_input) { double("decorated input") }
+  let(:input) { double("input") }
+
   describe "#create" do
-    it "should return an input that can have a hint" do
-      object = GenericAsset.new
-      result = described_class.create(object, :lcsubject)
-      expect(result.property).to eq :lcsubject
-      expect(result.options).to include ({:hint => nil})
+    it "decorate the input" do
+      object = build_object
+
+      result = subject.create(object, :lcsubject)
+
+      expect(result).to eq decorated_input
+      expect(decorator).to have_received(:new).with(input)
+      expect(base_factory).to have_received(:create).with(object, :lcsubject)
     end
+
+    def build_object
+      instance_double(GenericAssetForm)
+    end
+  end
+
+  def build_input_factory
+    f = object_double(HydraEditor::Fields::Factory)
+    allow(f).to receive(:create).and_return(input)
+    f
+  end
+  def build_decorator
+    f = object_double(HasHintOption)
+    allow(f).to receive(:new).and_return(decorated_input)
+    f
   end
 end

--- a/spec/forms/oregon_digital/fields/input_factory_spec.rb
+++ b/spec/forms/oregon_digital/fields/input_factory_spec.rb
@@ -2,35 +2,22 @@ require 'rails_helper'
 
 RSpec.describe OregonDigital::Fields::InputFactory do
   subject { described_class.new(base_factory, decorator) }
-  let(:base_factory) { build_input_factory }
-  let(:decorator) { build_decorator }
+  let(:base_factory) { object_double(HydraEditor::Fields::Factory) }
+  let(:decorator) { object_double(HasHintOption) }
+  let(:object) { instance_double(GenericAssetForm) }
   let(:decorated_input) { double("decorated input") }
   let(:input) { double("input") }
+  let(:property) { :lcsubject }
+  let(:result) { subject.create(object, property) }
 
   describe "#create" do
     it "decorate the input" do
-      object = build_object
-
-      result = subject.create(object, :lcsubject)
+      allow(base_factory).to receive(:create).and_return(input)
+      allow(decorator).to receive(:new).and_return(decorated_input)
 
       expect(result).to eq decorated_input
       expect(decorator).to have_received(:new).with(input)
       expect(base_factory).to have_received(:create).with(object, :lcsubject)
     end
-
-    def build_object
-      instance_double(GenericAssetForm)
-    end
-  end
-
-  def build_input_factory
-    f = object_double(HydraEditor::Fields::Factory)
-    allow(f).to receive(:create).and_return(input)
-    f
-  end
-  def build_decorator
-    f = object_double(HasHintOption)
-    allow(f).to receive(:new).and_return(decorated_input)
-    f
   end
 end

--- a/spec/views/records/_form.html.erb_spec.rb
+++ b/spec/views/records/_form.html.erb_spec.rb
@@ -20,4 +20,7 @@ RSpec.describe "records/_form" do
   it "should have a named file field" do
     expect(rendered).to have_selector "input[type=file][name='image[content]']"
   end
+  it "should have the hint show up" do
+    expect(rendered).to have_css ".help-block"
+  end
 end

--- a/spec/views/records/_form.html.erb_spec.rb
+++ b/spec/views/records/_form.html.erb_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe "records/_form" do
   end
 
   let(:resource) do
-    Image.new
+    ValidatedAssetRepository.new(Image).new
   end
   let(:params) do
     {


### PR DESCRIPTION
Fixes #79 

This is the rest of the logic needed to regulate which properties are required to have URI's. Some delegation was required to squish down some of the method calls. Updating tests was necessary since some of the previously expected interfaces had changed. Dependency injection is also happening now in the initializer to make things easier to change.

@jechols @lsat12357 @luisgreg99 review please! :+1: