### PR TITLE
Bugfix/thumbnails

### DIFF
--- a/app/values/capistrano_aware_path.rb
+++ b/app/values/capistrano_aware_path.rb
@@ -1,0 +1,12 @@
+class CapistranoAwarePath < SimpleDelegator
+  def initialize(path_or_string)
+    super(clean(path_or_string))
+  end
+
+  private
+
+  def clean(path)
+    path = path.to_s.gsub(/releases\/.*?\//, 'release_path/')
+    Pathname.new(path.gsub(/releases\/[^\/]*$/, 'release_path'))
+  end
+end

--- a/app/values/capistrano_aware_path.rb
+++ b/app/values/capistrano_aware_path.rb
@@ -6,7 +6,7 @@ class CapistranoAwarePath < SimpleDelegator
   private
 
   def clean(path)
-    path = path.to_s.gsub(/releases\/.*?\//, 'release_path/')
-    Pathname.new(path.gsub(/releases\/[^\/]*$/, 'release_path'))
+    path = path.to_s.gsub(/releases\/.*?\//, 'shared/')
+    Pathname.new(path.gsub(/releases\/[^\/]*$/, 'shared'))
   end
 end

--- a/app/values/derivative_path.rb
+++ b/app/values/derivative_path.rb
@@ -20,8 +20,8 @@ class DerivativePath < SimpleDelegator
   private
 
   def clean(path)
-    p = Pathname.new(path.to_s.gsub(/releases\/.*?\//, 'release_path/'))
-    p = Pathname.new(p.to_s.gsub(/releases\/[^\/]*$/, 'release_path'))
+    path = path.to_s.gsub(/releases\/.*?\//, 'release_path/')
+    Pathname.new(path.gsub(/releases\/[^\/]*$/, 'release_path'))
   end
 
   def injector

--- a/app/values/derivative_path.rb
+++ b/app/values/derivative_path.rb
@@ -1,28 +1,25 @@
 class DerivativePath < SimpleDelegator
   delegate :to_s, :to => :__getobj__
+  attr_reader :path_factory
 
-  def initialize(string_or_path)
-    super(clean(string_or_path))
+  def initialize(string_or_path, path_factory=CapistranoAwarePath)
+    @path_factory = path_factory
+    super(path_factory.new(string_or_path))
   end
 
   def relative_path
-    Pathname.new("/").join(relative_path_from(derivative_base))
+    path_factory.new("/").join(relative_path_from(derivative_base))
   end
 
   def derivative_base
-    clean(injector.derivative_base.parent)
+    path_factory.new(injector.derivative_base.parent)
   end
 
   def derivative_type
-    relative_path_from(clean(injector.derivative_base)).to_s.split("/").first.singularize.underscore.to_sym
+    relative_path_from(path_factory.new(injector.derivative_base)).to_s.split("/").first.singularize.underscore.to_sym
   end
 
   private
-
-  def clean(path)
-    path = path.to_s.gsub(/releases\/.*?\//, 'release_path/')
-    Pathname.new(path.gsub(/releases\/[^\/]*$/, 'release_path'))
-  end
 
   def injector
     @inkjector ||= OregonDigital.derivative_injector

--- a/app/values/derivative_path.rb
+++ b/app/values/derivative_path.rb
@@ -2,7 +2,7 @@ class DerivativePath < SimpleDelegator
   delegate :to_s, :to => :__getobj__
   attr_reader :path_factory
 
-  def initialize(string_or_path, path_factory=CapistranoAwarePath)
+  def initialize(string_or_path, path_factory=Pathname)
     @path_factory = path_factory
     super(path_factory.new(string_or_path))
   end

--- a/app/values/derivative_path.rb
+++ b/app/values/derivative_path.rb
@@ -20,7 +20,8 @@ class DerivativePath < SimpleDelegator
   private
 
   def clean(path)
-    Pathname.new(path.to_s.gsub(/releases\/.*?\//, 'release_path'))
+    p = Pathname.new(path.to_s.gsub(/releases\/.*?\//, 'release_path/'))
+    p = Pathname.new(p.to_s.gsub(/releases\/[^\/]*$/, 'release_path'))
   end
 
   def injector

--- a/app/values/derivative_path.rb
+++ b/app/values/derivative_path.rb
@@ -2,7 +2,7 @@ class DerivativePath < SimpleDelegator
   delegate :to_s, :to => :__getobj__
 
   def initialize(string_or_path)
-    super(Pathname.new(string_or_path.to_s))
+    super(clean(string_or_path))
   end
 
   def relative_path
@@ -10,14 +10,18 @@ class DerivativePath < SimpleDelegator
   end
 
   def derivative_base
-    injector.derivative_base.parent
+    clean(injector.derivative_base.parent)
   end
 
   def derivative_type
-    relative_path_from(injector.derivative_base).to_s.split("/").first.singularize.underscore.to_sym
+    relative_path_from(clean(injector.derivative_base)).to_s.split("/").first.singularize.underscore.to_sym
   end
 
   private
+
+  def clean(path)
+    Pathname.new(path.to_s.gsub(/releases\/.*?\//, 'release_path'))
+  end
 
   def injector
     @inkjector ||= OregonDigital.derivative_injector

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -17,7 +17,7 @@ set :branch, config['branch']
 set :deploy_via, :remote_cache
 set :use_sudo, false
 set :keep_releases, 5
-set :shared_children, shared_children + %w{pids sockets tmp public/uploads jetty}
+set :shared_children, shared_children + %w{pids sockets tmp public/uploads jetty media}
 set :ssh_options, {:forward_agent => true}
 
 # if you want to clean up old releases on each deploy uncomment this:

--- a/lib/oregon_digital/derivatives/derivative_callback.rb
+++ b/lib/oregon_digital/derivatives/derivative_callback.rb
@@ -8,7 +8,7 @@ module OregonDigital::Derivatives
 
     def success(type, path)
       asset.__send__(:"has_#{type}=", true)
-      asset.__send__(:"#{type}_path=", path.to_s)
+      asset.__send__(:"#{type}_path=", CapistranoAwarePath.new(path).to_s)
     end
 
   end

--- a/spec/lib/oregon_digital/derivatives/derivative_callback_spec.rb
+++ b/spec/lib/oregon_digital/derivatives/derivative_callback_spec.rb
@@ -15,6 +15,14 @@ RSpec.describe OregonDigital::Derivatives::DerivativeCallback do
 
   describe "#success" do
     context "for an image" do
+      context "when given a capistrano path" do
+        before do
+          subject.success(:thumbnail, Pathname.new("/data0/www/od2/releases/12312123/media/thumbnails/1/2/2.jpg"))
+        end
+        it "should set path to the cap symlink" do
+          expect(asset).to have_received(:thumbnail_path=).with("/data0/www/od2/shared/media/thumbnails/1/2/2.jpg")
+        end
+      end
       image_paths.each do |type, path|
         before do
           subject.success(type, path.to_s)

--- a/spec/values/capistrano_aware_path_spec.rb
+++ b/spec/values/capistrano_aware_path_spec.rb
@@ -1,0 +1,18 @@
+require 'rails_helper'
+
+RSpec.describe CapistranoAwarePath do
+  subject { described_class.new(path) }
+
+  context "when given a capistrano release path" do
+    let(:path) { "/data0/www/od2/releases/123123/media/1.jpg" }
+    it "should point to the shared media path" do
+      expect(subject.to_s).to eq "/data0/www/od2/shared/media/1.jpg"
+    end
+  end
+  context "when given the capistrano release root" do
+    let(:path) { "/data0/www/od2/releases/123123" }
+    it "should point to the shared media path" do
+      expect(subject.to_s).to eq "/data0/www/od2/shared"
+    end
+  end
+end

--- a/spec/values/derivative_path_spec.rb
+++ b/spec/values/derivative_path_spec.rb
@@ -21,28 +21,12 @@ RSpec.describe DerivativePath do
         expect(subject.relative_path).to eq Pathname.new("/media/thumbnails/t/s/test.jpg")
       end
     end
-    context "given a path from the server" do
-      let(:path) { Pathname.new("/data0/od2.library.oregonstate.edu/releases/20150623202821/media/thumbnails/j/s/d08f659sj.jpg") }
-      it "should return correctly" do
-        allow(subject).to receive(:injector).and_return(injector)
-        allow(injector).to receive(:derivative_base).and_return(Pathname.new("/data0/od2.library.oregonstate.edu/releases/20150623221531/media"))
-        expect(subject.relative_path).to eq Pathname.new("/media/thumbnails/j/s/d08f659sj.jpg")
-      end
-    end
   end
 
   describe "#derivative_type" do
     let(:result) { subject.derivative_type }
     context "given a thumbnail" do
       it "should return :thumbnail" do
-        expect(result).to eq :thumbnail
-      end
-    end
-    context "given a path from the server" do
-      let(:path) { Pathname.new("/data0/od2.library.oregonstate.edu/releases/20150623202821/media/thumbnails/j/s/d08f659sj.jpg") }
-      it "should return correctly" do
-        allow(subject).to receive(:injector).and_return(injector)
-        allow(injector).to receive(:derivative_base).and_return(Pathname.new("/data0/od2.library.oregonstate.edu/releases/20150623221531/media"))
         expect(result).to eq :thumbnail
       end
     end

--- a/spec/values/derivative_path_spec.rb
+++ b/spec/values/derivative_path_spec.rb
@@ -30,6 +30,14 @@ RSpec.describe DerivativePath do
         expect(result).to eq :thumbnail
       end
     end
+    context "given a path from the server" do
+      let(:path) { Pathname.new("/data0/od2.library.oregonstate.edu/releases/20150623202821/media/thumbnails/j/s/d08f659sj.jpg") }
+      it "should return correctly" do
+        allow(subject).to receive(:injector).and_return(injector)
+        allow(injector).to receive(:derivative_base).and_return(Pathname.new("/data0/od2.library.oregonstate.edu/releases/20150623221531/media"))
+        expect(result).to eq :thumbnail
+      end
+    end
     context "given a pyramidal" do
       let(:path) { injector.pyramidal_path("test") }
       it "should return a pyramidal" do

--- a/spec/values/derivative_path_spec.rb
+++ b/spec/values/derivative_path_spec.rb
@@ -21,6 +21,14 @@ RSpec.describe DerivativePath do
         expect(subject.relative_path).to eq Pathname.new("/media/thumbnails/t/s/test.jpg")
       end
     end
+    context "given a path from the server" do
+      let(:path) { Pathname.new("/data0/od2.library.oregonstate.edu/releases/20150623202821/media/thumbnails/j/s/d08f659sj.jpg") }
+      it "should return correctly" do
+        allow(subject).to receive(:injector).and_return(injector)
+        allow(injector).to receive(:derivative_base).and_return(Pathname.new("/data0/od2.library.oregonstate.edu/releases/20150623221531/media"))
+        expect(subject.relative_path).to eq Pathname.new("/media/thumbnails/j/s/d08f659sj.jpg")
+      end
+    end
   end
 
   describe "#derivative_type" do

--- a/spec/views/catalog/_thumbnail_default.html.erb_spec.rb
+++ b/spec/views/catalog/_thumbnail_default.html.erb_spec.rb
@@ -25,5 +25,11 @@ RSpec.describe "catalog/_thumbnail_default.html.erb" do
         expect(rendered).to have_selector "img[src='/media/thumbnails/3/1/13.jpg']"
       end
     end
+    context "when there's no thumbnail" do
+      let(:solr_hash) { {:id => 1} }
+      it "should not show anything" do
+        expect(rendered).not_to have_selector "img"
+      end
+    end
   end
 end


### PR DESCRIPTION
Derivative Path couldn't handle when the stored path no longer existed because it was a relative path to a Capistrano release that isn't around anymore.