### PR TITLE
Alternative Labels

### DIFF
--- a/app/decorators/has_alternative_label.rb
+++ b/app/decorators/has_alternative_label.rb
@@ -1,0 +1,11 @@
+class HasAlternativeLabel < SimpleDelegator
+  def alternative_labels
+    get_values(RDF::SKOS.altLabel)
+  end
+
+  class Factory < SimpleDelegator
+    def new(*args)
+      HasAlternativeLabel.new(super)
+    end
+  end
+end

--- a/app/enhancements/alt_label_enhancement.rb
+++ b/app/enhancements/alt_label_enhancement.rb
@@ -1,0 +1,26 @@
+class AltLabelEnhancement
+  pattr_initialize :raw_property
+
+  def properties
+    [SolrProperty.new(solr_identifier, alternative_labels)]
+  end
+
+  private
+
+  def alternative_labels
+    resources.flat_map(&:alternative_labels)
+  end
+
+  def resources
+    @resources ||= OnlyUris.new(raw_property.values)
+      .map{|x| resource_factory.new(x)}
+  end
+
+  def solr_identifier
+    raw_property.derivative_properties[:alternative_label].property_key
+  end
+
+  def resource_factory
+    HasAlternativeLabel::Factory.new(TriplePoweredResource)
+  end
+end

--- a/app/models/enriched_solr_document.rb
+++ b/app/models/enriched_solr_document.rb
@@ -22,7 +22,7 @@ class EnrichedSolrDocument
   private
 
   def enhancements
-    CompositeEnhancementFactory.new(LabelEnhancement)
+    CompositeEnhancementFactory.new(LabelEnhancement, AltLabelEnhancement)
   end
 
   def properties

--- a/app/values/solr_property.rb
+++ b/app/values/solr_property.rb
@@ -18,7 +18,8 @@ class SolrProperty
 
   def derivative_properties
     {
-      :preferred_label => derivative_key("preferred_label")
+      :preferred_label => derivative_key("preferred_label"),
+      :alternative_label => derivative_key("alternative_label")
     }
   end
 

--- a/spec/enhancements/alt_label_enhancement_spec.rb
+++ b/spec/enhancements/alt_label_enhancement_spec.rb
@@ -1,0 +1,27 @@
+require 'rails_helper'
+
+RSpec.describe AltLabelEnhancement do
+  subject { described_class.new(property) }
+  let(:property) { SolrProperty.new("lcsubject_ssim", value) }
+  let(:value) { "http://localhost:40/1" }
+  describe "#properties" do
+    context "when there's alt labels" do
+      it "should return a nice property" do
+        build_resource(uri: value, label: "Test").tap do |r|
+          r << [r.rdf_subject, RDF::SKOS.altLabel, "Alternative"]
+          r << [r.rdf_subject, RDF::SKOS.altLabel, "More labels"]
+        end.persist!
+
+        property = subject.properties.first
+        expect(property.values).to eq ["Alternative", "More labels"]
+        expect(property.key).to eq "lcsubject_alternative_label"
+        expect(property.solr_identifier).to eq "ssim"
+      end
+    end
+    context "when there's no label" do
+      it "should return an empty array property" do
+        expect(subject.properties.first.values).to eq []
+      end
+    end
+  end
+end

--- a/spec/models/blacklight_config/search_field_spec.rb
+++ b/spec/models/blacklight_config/search_field_spec.rb
@@ -37,6 +37,7 @@ RSpec.describe BlacklightConfig::SearchField do
       it "should add derivative keys" do
         qf = subject.solr_parameters[:qf]
         expect(qf).to include Solrizer.solr_name(field+"_preferred_label", :stored_searchable)
+        expect(qf).to include Solrizer.solr_name(field+"_alternative_label", :stored_searchable)
       end
     end
   end

--- a/spec/models/enriched_solr_document_spec.rb
+++ b/spec/models/enriched_solr_document_spec.rb
@@ -39,6 +39,22 @@ RSpec.describe EnrichedSolrDocument do
         expect(document_result).to eq ( {} )
       end
     end
+    context "when there are alternative labels" do
+      let(:solr_document) { {"lcsubject_ssim" => [uri.to_s]} }
+      let(:uri) { "http://localhost:41/1" }
+      it "should add them" do
+        build_resource(uri: uri, label: "Test").tap do |r|
+          r << [r.rdf_subject, RDF::SKOS.altLabel, "Another Test"]
+        end.persist!
+
+        expect(document_result).to eq (
+          {
+            "lcsubject_preferred_label_ssim" => ["Test"],
+            "lcsubject_alternative_label_ssim" => ["Another Test"]
+          }
+        )
+      end
+    end
     context "when there are fields with no URIs" do
       let(:solr_document) { {"id" => "test", "lcsubject_ssim" => ["test", uri.to_s]} }
       let(:uri) { "http://localhost:41/1" }

--- a/spec/values/solr_property_spec.rb
+++ b/spec/values/solr_property_spec.rb
@@ -16,6 +16,9 @@ RSpec.describe SolrProperty do
     it "should return preferred label" do
       expect(result[:preferred_label].key).to eq "lc_subject_preferred_label"
     end
+    it "should return alternative label" do
+      expect(result[:alternative_label].key).to eq "lc_subject_alternative_label"
+    end
   end
 
   describe "#values" do


### PR DESCRIPTION
Closes #132.

I really want to get this in before the demo. If we want to remove discoverability around alternative labels, we can always pull it back out.