### PR TITLE
Add settings up Jetty to bin/setup

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -20,6 +20,9 @@ Dir.chdir APP_ROOT do
   puts "\n== Preparing database =="
   system "bin/rake db:setup"
 
+  puts "\n== Setting up Jetty =="
+  system "bundle exec rake jetty:clean && bundle exec rake jetty:config"
+
   puts "\n== Removing old logs and tempfiles =="
   system "rm -f log/*"
   system "rm -rf tmp/cache"


### PR DESCRIPTION
At first, I followed suit and used bin/rake, but there was environment problems
that were solved by using bundle exec for both tasks.

I also had to install vips, but think it was appropriate to install that in this script. Same feeling for mysql.