### PR TITLE
Database Configurable Facets

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -98,6 +98,7 @@ group :development, :test do
   gem 'newrelic_rpm'
   gem 'capybara-screenshot'
   gem 'coveralls', :require => false
+  gem 'shoulda-matchers', :require => false
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -492,6 +492,8 @@ GEM
     sdoc (0.4.1)
       json (~> 1.7, >= 1.7.7)
       rdoc (~> 4.0)
+    shoulda-matchers (2.8.0)
+      activesupport (>= 3.0.0)
     simple_form (3.1.0)
       actionpack (~> 4.0)
       activemodel (~> 4.0)
@@ -617,6 +619,7 @@ DEPENDENCIES
   ruby-vips
   sass-rails (~> 5.0)
   sdoc (~> 0.4.0)
+  shoulda-matchers
   simplecov
   spring
   spring-commands-rspec

--- a/app/controllers/admin/facets_controller.rb
+++ b/app/controllers/admin/facets_controller.rb
@@ -1,7 +1,6 @@
 class Admin::FacetsController < AdminController
   def index
     @facets = FacetConfigurationFacade.new
-    @facet = FacetField.new
   end
 
   def create

--- a/app/controllers/admin/facets_controller.rb
+++ b/app/controllers/admin/facets_controller.rb
@@ -1,15 +1,23 @@
 class Admin::FacetsController < AdminController
   def index
-    @solr_fields = iterator_factory.new(all_solr_fields)
+    @facets = FacetConfigurationFacade.new
+    @facet = FacetField.new
+  end
+
+  def create
+    if FacetField.create(facet_field_params)
+      flash[:success] = "Facet field created"
+      redirect_to admin_facets_path
+    else
+      flash[:error] = "Failed to create facet"
+      redirect_to admin_facets_path
+    end
   end
 
   private
 
-  def all_solr_fields
-    SolrFieldSummary.where(:field => "*")
+  def facet_field_params
+    params.require(:facet_field).permit(:key)
   end
 
-  def iterator_factory
-    FacetableSolrFieldIterator
-  end
 end

--- a/app/controllers/admin/facets_controller.rb
+++ b/app/controllers/admin/facets_controller.rb
@@ -1,0 +1,5 @@
+class Admin::FacetsController < AdminController
+  def index
+    @solr_fields = SolrFieldSummary.where(:field => "*")
+  end
+end

--- a/app/controllers/admin/facets_controller.rb
+++ b/app/controllers/admin/facets_controller.rb
@@ -1,5 +1,15 @@
 class Admin::FacetsController < AdminController
   def index
-    @solr_fields = FacetableSolrFieldIterator.new(SolrFieldSummary.where(:field => "*"))
+    @solr_fields = iterator_factory.new(all_solr_fields)
+  end
+
+  private
+
+  def all_solr_fields
+    SolrFieldSummary.where(:field => "*")
+  end
+
+  def iterator_factory
+    FacetableSolrFieldIterator
   end
 end

--- a/app/controllers/admin/facets_controller.rb
+++ b/app/controllers/admin/facets_controller.rb
@@ -6,15 +6,27 @@ class Admin::FacetsController < AdminController
 
   def create
     if FacetField.create(facet_field_params)
-      flash[:success] = "Facet field created"
-      redirect_to admin_facets_path
-    else
-      flash[:error] = "Failed to create facet"
+      flash[:success] = t('admin.facets.field_created')
       redirect_to admin_facets_path
     end
   end
 
+  def destroy
+    begin
+      if find_facet(params[:id]).destroy
+        flash[:success] = t('admin.facets.destroy.success')
+      end
+    rescue
+      flash[:alert] = t('admin.facets.destroy.fail')
+    end
+    redirect_to admin_facets_path
+  end
+
   private
+
+  def find_facet(id)
+    FacetField.find(id)
+  end
 
   def facet_field_params
     params.require(:facet_field).permit(:key)

--- a/app/controllers/admin/facets_controller.rb
+++ b/app/controllers/admin/facets_controller.rb
@@ -1,5 +1,5 @@
 class Admin::FacetsController < AdminController
   def index
-    @solr_fields = SolrFieldSummary.where(:field => "*")
+    @solr_fields = FacetableSolrFieldIterator.new(SolrFieldSummary.where(:field => "*"))
   end
 end

--- a/app/decorators/has_facet_field.rb
+++ b/app/decorators/has_facet_field.rb
@@ -1,0 +1,7 @@
+class HasFacetField < SimpleDelegator
+  attr_reader :facet
+  def initialize(object, facet_field)
+    @facet = facet_field
+    super(object)
+  end
+end

--- a/app/decorators/no_derivative_properties.rb
+++ b/app/decorators/no_derivative_properties.rb
@@ -1,0 +1,5 @@
+class NoDerivativeProperties < SimpleDelegator
+  def derivative_properties
+    {}
+  end
+end

--- a/app/enumerators/facetable_solr_field_iterator.rb
+++ b/app/enumerators/facetable_solr_field_iterator.rb
@@ -1,0 +1,24 @@
+class FacetableSolrFieldIterator
+  include Enumerable
+  pattr_initialize :solr_field_summary
+
+  def each
+    sorted.each do |s|
+      yield s
+    end
+  end
+
+  private
+
+  def sorted
+    only_data_model_keys.sort_by{|k, v| -v.distinct}
+  end
+
+  def only_data_model_keys
+    solr_field_summary.to_h.slice(*data_model_properties)
+  end
+
+  def data_model_properties
+    ODDataModel.properties.map(&:name)
+  end
+end

--- a/app/enumerators/facetable_solr_field_iterator.rb
+++ b/app/enumerators/facetable_solr_field_iterator.rb
@@ -11,7 +11,11 @@ class FacetableSolrFieldIterator
   private
 
   def sorted
-    only_data_model_keys.sort_by{|k, v| -v.distinct}
+    flattened_derivative_properties.sort_by{|k, v| -v.distinct}
+  end
+
+  def flattened_derivative_properties
+    FlatteningDerivativePropertiesIterator.new(only_data_model_keys).to_h
   end
 
   def only_data_model_keys

--- a/app/enumerators/facetable_solr_field_iterator.rb
+++ b/app/enumerators/facetable_solr_field_iterator.rb
@@ -11,15 +11,22 @@ class FacetableSolrFieldIterator
   private
 
   def sorted
-    flattened_derivative_properties.sort_by{|k, v| -v.distinct}
-  end
-
-  def flattened_derivative_properties
-    FlatteningDerivativePropertiesIterator.new(only_data_model_keys).to_h
+    only_data_model_keys.sort_by{|k, v| -v.distinct}
   end
 
   def only_data_model_keys
-    solr_field_summary.to_h.slice(*data_model_properties)
+    solr_field_summary.to_h.slice(*good_keys)
+  end
+
+  def good_keys
+    (data_model_properties | derivative_keys).map(&:to_sym)
+  end
+
+  def derivative_keys
+    data_model_properties.flat_map do |property|
+      s = SolrProperty.new(property.to_s+"_ssim")
+      s.derivative_properties.values.map(&:key)
+    end
   end
 
   def data_model_properties

--- a/app/enumerators/flattening_derivative_properties_iterator.rb
+++ b/app/enumerators/flattening_derivative_properties_iterator.rb
@@ -1,0 +1,13 @@
+class FlatteningDerivativePropertiesIterator
+  include Enumerable
+  pattr_initialize :solr_field_summary
+  def each
+    solr_field_summary.each do |prop, field|
+      yield [prop, NoDerivativeProperties.new(field)]
+      field.derivative_properties.each do |derivative_property, derivative_field|
+        property = [prop, derivative_property].map(&:to_s).join("_").to_sym
+        yield [property, derivative_field]
+      end
+    end
+  end
+end

--- a/app/facades/facet_configuration_facade.rb
+++ b/app/facades/facet_configuration_facade.rb
@@ -1,0 +1,31 @@
+class FacetConfigurationFacade
+  def active
+    solr_field_iterator.to_h.slice(*facet_keys)
+  end
+
+  def inactive
+    solr_field_iterator.to_h.except(*facet_keys)
+  end
+
+  private
+
+  def all_facet_fields
+    @all_facet_fields ||= FacetField.all
+  end
+
+  def facet_keys
+    @facet_keys ||= all_facet_fields.map(&:key).map(&:to_sym)
+  end
+
+  def all_solr_fields
+    @all_solr_fields ||= SolrFieldSummary.where(:field => "*")
+  end
+
+  def solr_field_iterator
+    @solr_field_iterator ||= iterator_factory.new(all_solr_fields)
+  end
+
+  def iterator_factory
+    FacetableSolrFieldIterator
+  end
+end

--- a/app/facades/facet_configuration_facade.rb
+++ b/app/facades/facet_configuration_facade.rb
@@ -1,14 +1,10 @@
 class FacetConfigurationFacade
   def active
-    solr_field_iterator.to_h.slice(*facet_keys).map do |k, v|
-      [k, HasFacetField.new(v, grouped_facets[k].first)]
-    end
+    solr_field_iterator.to_h.slice(*facet_keys)
   end
 
   def inactive
-    solr_field_iterator.to_h.except(*facet_keys).map do |k, v|
-      [k, HasFacetField.new(v, FacetField.new)]
-    end
+    solr_field_iterator.to_h.except(*facet_keys)
   end
 
   private
@@ -30,7 +26,9 @@ class FacetConfigurationFacade
   end
 
   def solr_field_iterator
-    @solr_field_iterator ||= iterator_factory.new(all_solr_fields)
+    @solr_field_iterator ||= iterator_factory.new(all_solr_fields).map do |k, v|
+      [k, HasFacetField.new(v, grouped_facets[k].try(:first) || FacetField.new)]
+    end
   end
 
   def iterator_factory

--- a/app/facades/facet_configuration_facade.rb
+++ b/app/facades/facet_configuration_facade.rb
@@ -1,16 +1,24 @@
 class FacetConfigurationFacade
   def active
-    solr_field_iterator.to_h.slice(*facet_keys)
+    solr_field_iterator.to_h.slice(*facet_keys).map do |k, v|
+      [k, HasFacetField.new(v, grouped_facets[k].first)]
+    end
   end
 
   def inactive
-    solr_field_iterator.to_h.except(*facet_keys)
+    solr_field_iterator.to_h.except(*facet_keys).map do |k, v|
+      [k, HasFacetField.new(v, FacetField.new)]
+    end
   end
 
   private
 
   def all_facet_fields
     @all_facet_fields ||= FacetField.all
+  end
+
+  def grouped_facets
+    @grouped_facets ||= all_facet_fields.group_by(&:key).symbolize_keys
   end
 
   def facet_keys

--- a/app/models/blacklight_config.rb
+++ b/app/models/blacklight_config.rb
@@ -26,7 +26,8 @@ class BlacklightConfig
       ShowActions.new(configuration),
       ThumbnailConfiguration.new(configuration),
       Gallery.new(configuration),
-      IndexConfiguration.new(configuration)
+      IndexConfiguration.new(configuration),
+      FacetFields.new(configuration)
     ]
   end
 

--- a/app/models/blacklight_config/facet_fields.rb
+++ b/app/models/blacklight_config/facet_fields.rb
@@ -4,7 +4,7 @@ class BlacklightConfig
     
     def run
       facet_fields.each do |field|
-        configuration.add_facet_field ActiveFedora::SolrQueryBuilder.solr_name(field.key, :symbol)
+        configuration.add_facet_field ActiveFedora::SolrQueryBuilder.solr_name(field.key, :symbol), :label => field.key.titleize
       end
       configuration.add_facet_fields_to_solr_request!
     end

--- a/app/models/blacklight_config/facet_fields.rb
+++ b/app/models/blacklight_config/facet_fields.rb
@@ -4,7 +4,7 @@ class BlacklightConfig
     
     def run
       facet_fields.each do |field|
-        configuration.add_facet_field "#{field.key}_ssim"
+        configuration.add_facet_field ActiveFedora::SolrQueryBuilder.solr_name(field.key, :symbol)
       end
       configuration.add_facet_fields_to_solr_request!
     end

--- a/app/models/blacklight_config/facet_fields.rb
+++ b/app/models/blacklight_config/facet_fields.rb
@@ -1,0 +1,18 @@
+class BlacklightConfig
+  class FacetFields
+    pattr_initialize :configuration
+    
+    def run
+      facet_fields.each do |field|
+        configuration.add_facet_field "#{field.key}_ssim"
+      end
+      configuration.add_facet_fields_to_solr_request!
+    end
+
+    private
+
+    def facet_fields
+      @facet_fields ||= FacetField.all
+    end
+  end
+end

--- a/app/models/facet_field.rb
+++ b/app/models/facet_field.rb
@@ -1,2 +1,3 @@
 class FacetField < ActiveRecord::Base
+  validates :key, :presence => true
 end

--- a/app/models/facet_field.rb
+++ b/app/models/facet_field.rb
@@ -1,0 +1,2 @@
+class FacetField < ActiveRecord::Base
+end

--- a/app/models/solr_field_summary.rb
+++ b/app/models/solr_field_summary.rb
@@ -2,7 +2,7 @@ class SolrFieldSummary
   class << self
     def where(params={})
       new(
-        Query.new(params).result
+        SolrFieldSummary::Query.new(params).result
       )
     end
   end
@@ -51,6 +51,8 @@ class SolrFieldSummary
 
   # Sort by key length so that non-derivative properties come first.
   def sorted_field_summary
-    field_summary_hash.sort_by{|k, _| k.to_s.length}
+    field_summary_hash.sort_by{|k, _| k.to_s.length}.select do |k, v|
+      SolrProperty.new(k).solr_identifier == "ssim"
+    end
   end
 end

--- a/app/models/solr_field_summary.rb
+++ b/app/models/solr_field_summary.rb
@@ -8,7 +8,7 @@ class SolrFieldSummary
   end
 
   pattr_initialize :field_summary_hash
-  delegate :keys, :to => :cleaned_result
+  delegate :keys, :each, :to => :cleaned_result
 
   def [](key)
     cleaned_result[key.to_sym]
@@ -35,7 +35,9 @@ class SolrFieldSummary
     interim_result.select do |property, value|
       property.derivative_properties.each do |derivative_property_key, prop|
         derivative_properties << prop.property_key
-        value.derivative_properties[derivative_property_key] = interim_result[prop]
+        if interim_result[prop]
+          value.derivative_properties[derivative_property_key] = interim_result[prop]
+        end
       end
       !derivative_properties.include?(property.property_key)
     end

--- a/app/models/solr_field_summary.rb
+++ b/app/models/solr_field_summary.rb
@@ -1,0 +1,70 @@
+class SolrFieldSummary
+  class << self
+    def where(params={})
+      new(
+        Query.new(params).result
+      )
+    end
+  end
+
+  pattr_initialize :field_summary_hash
+  delegate :keys, :to => :cleaned_result
+
+  def [](key)
+    cleaned_result[key.to_sym]
+  end
+
+  def keys
+    cleaned_result.keys
+  end
+
+  private
+
+  def cleaned_result
+    derivative_properties = []
+    field_summary_hash.sort_by{|k, _| k.to_s.length }.each_with_object({}) do |(key, value), collector|
+      property = SolrProperty.new(key)
+      unless derivative_properties.include?(key)
+        field = Field.new(value)
+        property.derivative_properties.each do |derivative_property_key, prop|
+          derivative_properties << prop.property_key
+          field.derivative_properties[derivative_property_key] = Field.new(field_summary_hash[prop.property_key])
+        end
+        collector[property.key.to_sym] = field
+      end
+    end
+  end
+
+  class Field < OpenStruct
+    def derivative_properties
+      @derivative_properties ||= {}
+    end
+  end
+
+  class Query
+    attr_reader :field
+    def initialize(field:)
+      @field = field
+    end
+
+    def result
+      @result ||= solr_result["fields"]
+    end
+
+    private
+
+    def solr_result
+      solr.send_and_receive("admin/luke", :params => solr_params)
+    end
+
+    def solr_params
+      {
+        :fl => field
+      }
+    end
+
+    def solr
+      ActiveFedora.solr.conn
+    end
+  end
+end

--- a/app/models/solr_field_summary.rb
+++ b/app/models/solr_field_summary.rb
@@ -23,25 +23,10 @@ class SolrFieldSummary
 
   def cleaned_result
     @cleaned_result ||= Hash[
-      extract_derivative_properties.map do |k, v|
+      interim_result.map do |k, v|
         [k.key.to_sym, v]
       end
     ]
-  end
-
-  def extract_derivative_properties
-    derivative_properties = []
-    # Move all derivative property keys underneath their parent keys and don't
-    # select the derivatives.
-    interim_result.select do |property, value|
-      property.derivative_properties.each do |derivative_property_key, prop|
-        derivative_properties << prop.property_key
-        if interim_result[prop]
-          value.derivative_properties[derivative_property_key] = interim_result[prop]
-        end
-      end
-      !derivative_properties.include?(property.property_key)
-    end
   end
 
   def interim_result

--- a/app/models/solr_field_summary.rb
+++ b/app/models/solr_field_summary.rb
@@ -30,17 +30,13 @@ class SolrFieldSummary
   end
 
   def interim_result
-    sorted_field_summary.each_with_object({}) do |(key, value), collector|
+    field_summary_hash.each_with_object({}) do |(key, value), collector|
       property = SolrProperty.new(key)
       field = Field.new(value)
-      collector[property] = field
+      if property.solr_identifier == "ssim"
+        collector[property] = field
+      end
     end
   end
 
-  # Sort by key length so that non-derivative properties come first.
-  def sorted_field_summary
-    field_summary_hash.sort_by{|k, _| k.to_s.length}.select do |k, v|
-      SolrProperty.new(k).solr_identifier == "ssim"
-    end
-  end
 end

--- a/app/models/solr_field_summary.rb
+++ b/app/models/solr_field_summary.rb
@@ -6,6 +6,7 @@ class SolrFieldSummary
       )
     end
   end
+  include Enumerable
 
   pattr_initialize :field_summary_hash
   delegate :keys, :each, :to => :cleaned_result

--- a/app/models/solr_field_summary.rb
+++ b/app/models/solr_field_summary.rb
@@ -15,10 +15,6 @@ class SolrFieldSummary
     cleaned_result[key.to_sym]
   end
 
-  def keys
-    cleaned_result.keys
-  end
-
   private
 
   def cleaned_result

--- a/app/models/solr_field_summary/field.rb
+++ b/app/models/solr_field_summary/field.rb
@@ -1,9 +1,5 @@
 class SolrFieldSummary
   class Field < OpenStruct
-    def derivative_properties
-      @derivative_properties ||= {}
-    end
-
     def distinct
       super || 0
     end

--- a/app/models/solr_field_summary/field.rb
+++ b/app/models/solr_field_summary/field.rb
@@ -1,0 +1,7 @@
+class SolrFieldSummary
+  class Field < OpenStruct
+    def derivative_properties
+      @derivative_properties ||= {}
+    end
+  end
+end

--- a/app/models/solr_field_summary/field.rb
+++ b/app/models/solr_field_summary/field.rb
@@ -3,6 +3,11 @@ class SolrFieldSummary
     def derivative_properties
       @derivative_properties ||= {}
     end
+
+    def distinct
+      super || 0
+    end
+
     def topTerms
       super || []
     end

--- a/app/models/solr_field_summary/field.rb
+++ b/app/models/solr_field_summary/field.rb
@@ -3,5 +3,8 @@ class SolrFieldSummary
     def derivative_properties
       @derivative_properties ||= {}
     end
+    def topTerms
+      super || []
+    end
   end
 end

--- a/app/models/solr_field_summary/query.rb
+++ b/app/models/solr_field_summary/query.rb
@@ -1,0 +1,28 @@
+class SolrFieldSummary
+  class Query
+    attr_reader :field
+    def initialize(field:)
+      @field = field
+    end
+
+    def result
+      @result ||= solr_result["fields"]
+    end
+
+    private
+
+    def solr_result
+      solr.send_and_receive("admin/luke", :params => solr_params)
+    end
+
+    def solr_params
+      {
+        :fl => field
+      }
+    end
+
+    def solr
+      ActiveFedora.solr.conn
+    end
+  end
+end

--- a/app/values/solr_property.rb
+++ b/app/values/solr_property.rb
@@ -1,7 +1,7 @@
 ##
 # Represents a solr property in a solr document. Has a property_key and values
 # associated with it.
-class SolrProperty
+class SolrProperty < Struct.new(:property_key, :values)
   attr_reader :property_key, :values
   def initialize(property_key, values=[])
     @property_key = property_key.to_s
@@ -14,6 +14,10 @@ class SolrProperty
 
   def solr_identifier
     split_key.last
+  end
+
+  def eql?(other_property)
+    other_property.try(:property_key) == property_key && other_property.try(:values) == values
   end
 
   def derivative_properties

--- a/app/views/admin/facets/_field.html.erb
+++ b/app/views/admin/facets/_field.html.erb
@@ -1,11 +1,13 @@
 <div class="panel panel-default">
   <div class="panel-heading">
     <%= property.to_s.titleize %>
-    <% unless hide_button %>
-      <%= simple_form_for @facet, :url => admin_facets_path(@facet) do |f| %>
+    <% unless field.facet.persisted? %>
+      <%= simple_form_for field.facet, :url => admin_facets_path(field.facet) do |f| %>
         <%= f.input :key, :as => :hidden, :input_html => { :value => [parent,property].compact.map(&:to_s).join("_") } %>
         <%= f.submit %>
       <% end %>
+    <% else %>
+      <%= link_to "Delete", admin_facet_path(field.facet), :method => :delete %>
     <% end %>
   </div>
   <div class="panel-body">

--- a/app/views/admin/facets/_field.html.erb
+++ b/app/views/admin/facets/_field.html.erb
@@ -29,11 +29,5 @@
         </div>
       </div>
     </div>
-    <% unless field.derivative_properties.blank? %>
-      Derivative Properties
-      <% field.derivative_properties.each do |derivative_property, derivative_field| %>
-        <%= render :partial => "field", :locals => {:property => derivative_property, :field => derivative_field, :parent => property, :hide_button => hide_button} %>
-      <% end %>
-    <% end %>
   </div>
 </div>

--- a/app/views/admin/facets/_field.html.erb
+++ b/app/views/admin/facets/_field.html.erb
@@ -1,0 +1,29 @@
+<div class="panel panel-default">
+  <div class="panel-heading"><%= property.to_s.titleize %></div>
+  <div class="panel-body">
+    <div class="form-horizontal">
+      <div class="form-group">
+        <label class="control-label col-sm-2">Distinct Values:</label>
+        <div class="col-sm-10">
+          <p class="form-control-static"> <%= field.distinct %> </p>
+        </div>
+      </div>
+      <div class="form-group">
+        <label class="control-label col-sm-2">Top Terms:</label>
+        <div class="col-sm-10">
+          <ul class="form-control-static">
+            <% field.topTerms.each_slice(2) do |term, count| %>
+              <li><%= term %> - <%= count %></li>
+            <% end %>
+          </ul>
+        </div>
+      </div>
+    </div>
+    <% unless field.derivative_properties.blank? %>
+      Derivative Properties
+      <% field.derivative_properties.each do |derivative_property, derivative_field| %>
+        <%= render :partial => "field", :locals => {:property => derivative_property, :field => derivative_field} %>
+      <% end %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/admin/facets/_field.html.erb
+++ b/app/views/admin/facets/_field.html.erb
@@ -3,8 +3,8 @@
     <%= property.to_s.titleize %>
     <% unless field.facet.persisted? %>
       <%= simple_form_for field.facet, :url => admin_facets_path(field.facet) do |f| %>
-        <%= f.input :key, :as => :hidden, :input_html => { :value => [parent,property].compact.map(&:to_s).join("_") } %>
-        <%= f.submit %>
+        <%= f.input :key, :as => :hidden, :input_html => { :value => property.to_s} %>
+        <%= f.submit "Enable #{property.to_s.titleize} Facet" %>
       <% end %>
     <% else %>
       <%= link_to "Delete", admin_facet_path(field.facet), :method => :delete %>

--- a/app/views/admin/facets/_field.html.erb
+++ b/app/views/admin/facets/_field.html.erb
@@ -1,5 +1,13 @@
 <div class="panel panel-default">
-  <div class="panel-heading"><%= property.to_s.titleize %></div>
+  <div class="panel-heading">
+    <%= property.to_s.titleize %>
+    <% unless hide_button %>
+      <%= simple_form_for @facet, :url => admin_facets_path(@facet) do |f| %>
+        <%= f.input :key, :as => :hidden, :input_html => { :value => [parent,property].compact.map(&:to_s).join("_") } %>
+        <%= f.submit %>
+      <% end %>
+    <% end %>
+  </div>
   <div class="panel-body">
     <div class="form-horizontal">
       <div class="form-group">
@@ -22,7 +30,7 @@
     <% unless field.derivative_properties.blank? %>
       Derivative Properties
       <% field.derivative_properties.each do |derivative_property, derivative_field| %>
-        <%= render :partial => "field", :locals => {:property => derivative_property, :field => derivative_field} %>
+        <%= render :partial => "field", :locals => {:property => derivative_property, :field => derivative_field, :parent => property, :hide_button => hide_button} %>
       <% end %>
     <% end %>
   </div>

--- a/app/views/admin/facets/_field.html.erb
+++ b/app/views/admin/facets/_field.html.erb
@@ -18,16 +18,7 @@
           <p class="form-control-static"> <%= field.distinct %> </p>
         </div>
       </div>
-      <div class="form-group">
-        <label class="control-label col-sm-2">Top Terms:</label>
-        <div class="col-sm-10">
-          <ul class="form-control-static">
-            <% field.topTerms.each_slice(2) do |term, count| %>
-              <li><%= term %> - <%= count %></li>
-            <% end %>
-          </ul>
-        </div>
-      </div>
+      <%= render :partial => "top_terms", :locals => {:field => field} %>
     </div>
   </div>
 </div>

--- a/app/views/admin/facets/_top_terms.html.erb
+++ b/app/views/admin/facets/_top_terms.html.erb
@@ -1,0 +1,10 @@
+<div class="form-group">
+  <label class="control-label col-sm-2">Top Terms:</label>
+  <div class="col-sm-10">
+    <ul class="form-control-static">
+      <% field.topTerms.each_slice(2) do |term, count| %>
+        <li><%= term %> - <%= count %></li>
+    <% end %>
+    </ul>
+  </div>
+</div>

--- a/app/views/admin/facets/index.html.erb
+++ b/app/views/admin/facets/index.html.erb
@@ -1,9 +1,12 @@
 <h1> Currently Configured Facets </h1>
 <div id="facets">
+  <% @facets.active.each do |property, field| %>
+    <%= render :partial => "field", :locals => {:property => property, :field => field, :parent => nil, :hide_button => true} %>
+  <% end %>
 </div>
 
 <h1>Fields to Facet On</h1>
-<% @solr_fields.each do |property, field| %>
-  <%= render :partial => "field", :locals => {:property => property, :field => field} %>
+<% @facets.inactive.each do |property, field| %>
+  <%= render :partial => "field", :locals => {:property => property, :field => field, :parent => nil, :hide_button => false} %>
 <% end %>
 

--- a/app/views/admin/facets/index.html.erb
+++ b/app/views/admin/facets/index.html.erb
@@ -1,12 +1,12 @@
 <h1> Currently Configured Facets </h1>
 <div id="facets">
   <% @facets.active.each do |property, field| %>
-    <%= render :partial => "field", :locals => {:property => property, :field => field, :parent => nil, :hide_button => true} %>
+    <%= render :partial => "field", :locals => {:property => property, :field => field, :parent => nil, :create => false} %>
   <% end %>
 </div>
 
 <h1>Fields to Facet On</h1>
 <% @facets.inactive.each do |property, field| %>
-  <%= render :partial => "field", :locals => {:property => property, :field => field, :parent => nil, :hide_button => false} %>
+  <%= render :partial => "field", :locals => {:property => property, :field => field, :parent => nil, :create => true} %>
 <% end %>
 

--- a/app/views/admin/facets/index.html.erb
+++ b/app/views/admin/facets/index.html.erb
@@ -1,0 +1,9 @@
+<h1> Currently Configured Facets </h1>
+<div id="facets">
+</div>
+
+<h1>Fields to Facet On</h1>
+<% @solr_fields.each do |property, field| %>
+  <%= render :partial => "field", :locals => {:property => property, :field => field} %>
+<% end %>
+

--- a/app/views/admin/facets/index.html.erb
+++ b/app/views/admin/facets/index.html.erb
@@ -1,12 +1,12 @@
 <h1> Currently Configured Facets </h1>
 <div id="facets">
   <% @facets.active.each do |property, field| %>
-    <%= render :partial => "field", :locals => {:property => property, :field => field, :parent => nil, :create => false} %>
+    <%= render :partial => "field", :locals => {:property => property, :field => field} %>
   <% end %>
 </div>
 
 <h1>Fields to Facet On</h1>
 <% @facets.inactive.each do |property, field| %>
-  <%= render :partial => "field", :locals => {:property => property, :field => field, :parent => nil, :create => true} %>
+  <%= render :partial => "field", :locals => {:property => property, :field => field} %>
 <% end %>
 

--- a/app/views/admin/index.html.erb
+++ b/app/views/admin/index.html.erb
@@ -7,6 +7,7 @@
     <ul>
       <li><%= link_to "Ingest a New Record", hydra_editor.new_record_path %></li>
       <li><%= link_to "Edit User Roles", role_management.roles_path %></li>
+      <li><%= link_to "Configure Facets", admin_facets_path %></li>
     </ul>
   </div>
 </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -23,3 +23,9 @@ en:
   hello: "Hello world"
   sets:
     set_not_found: "Invalid set requested."
+  admin:
+    facets:
+      field_created: "Facet field configured"
+      destroy:
+        fail: "Failed to delete facet"
+        success: "Deleted facet"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,6 +6,9 @@ Rails.application.routes.draw do
 
 
   get '/admin', :to => 'admin#index', :as => "admin_index"
+  namespace :admin do
+    resources :facets
+  end
   resources :resource, :only => :show
   mount HydraEditor::Engine => '/'
 

--- a/db/migrate/20150702213649_create_facet_fields.rb
+++ b/db/migrate/20150702213649_create_facet_fields.rb
@@ -1,0 +1,10 @@
+class CreateFacetFields < ActiveRecord::Migration
+  def change
+    create_table :facet_fields do |t|
+      t.string :key
+
+      t.timestamps null: false
+    end
+    add_index :facet_fields, :key, :unique => true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150429165654) do
+ActiveRecord::Schema.define(version: 20150702213649) do
 
   create_table "bookmarks", force: :cascade do |t|
     t.integer  "user_id",       null: false
@@ -24,6 +24,34 @@ ActiveRecord::Schema.define(version: 20150429165654) do
   end
 
   add_index "bookmarks", ["user_id"], name: "index_bookmarks_on_user_id"
+
+  create_table "controlled_vocabularies", force: :cascade do |t|
+    t.string   "name"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  create_table "controlled_vocabulary_properties", force: :cascade do |t|
+    t.integer  "controlled_vocabulary_id"
+    t.string   "property"
+    t.datetime "created_at",               null: false
+    t.datetime "updated_at",               null: false
+  end
+
+  create_table "controlled_vocabulary_vocabularies", force: :cascade do |t|
+    t.integer  "controlled_vocabulary_id"
+    t.integer  "vocabulary_id"
+    t.datetime "created_at",               null: false
+    t.datetime "updated_at",               null: false
+  end
+
+  create_table "facet_fields", force: :cascade do |t|
+    t.string   "key"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  add_index "facet_fields", ["key"], name: "index_facet_fields_on_key", unique: true
 
   create_table "roles", force: :cascade do |t|
     t.string "name"
@@ -65,5 +93,11 @@ ActiveRecord::Schema.define(version: 20150429165654) do
 
   add_index "users", ["email"], name: "index_users_on_email", unique: true
   add_index "users", ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
+
+  create_table "vocabularies", force: :cascade do |t|
+    t.string   "base_uri"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
 
 end

--- a/spec/controllers/admin/facets_controller_spec.rb
+++ b/spec/controllers/admin/facets_controller_spec.rb
@@ -24,6 +24,29 @@ RSpec.describe Admin::FacetsController do
       post :create, :facet_field => {:key => "test"}
 
       expect(FacetField.first.key).to eq "test"
+      expect(flash[:success]).to eq I18n.t("admin.facets.field_created")
+    end
+  end
+
+  describe "#destroy" do
+    context "when the field doesn't exist" do
+      it "should redirect and show a flash" do
+        delete :destroy, :id => "1"
+
+        expect(response).to redirect_to admin_facets_path
+        expect(flash[:alert]).to eq I18n.t("admin.facets.destroy.fail")
+      end
+    end
+    context "when the field exists" do
+      it "should delete it" do
+        field = FacetField.create(:key => "test")
+
+        delete :destroy, :id => field.id.to_s
+
+        expect(response).to redirect_to admin_facets_path
+        expect(flash[:success]).to eq I18n.t("admin.facets.destroy.success")
+        expect(FacetField.where(:id => field.id).count).to eq 0
+      end
     end
   end
 end

--- a/spec/controllers/admin/facets_controller_spec.rb
+++ b/spec/controllers/admin/facets_controller_spec.rb
@@ -9,10 +9,12 @@ RSpec.describe Admin::FacetsController do
     it "should find the possible solr fields" do
       solr_fields = instance_double(SolrFieldSummary)
       allow(SolrFieldSummary).to receive(:where).with(:field => "*").and_return(solr_fields)
+      iterator = instance_double(FacetableSolrFieldIterator)
+      allow(FacetableSolrFieldIterator).to receive(:new).with(solr_fields).and_return(iterator)
 
       get :index
 
-      expect(assigns(:solr_fields)).to eq solr_fields
+      expect(assigns(:solr_fields)).to eq iterator
     end
   end
 end

--- a/spec/controllers/admin/facets_controller_spec.rb
+++ b/spec/controllers/admin/facets_controller_spec.rb
@@ -1,0 +1,18 @@
+require 'rails_helper'
+
+RSpec.describe Admin::FacetsController do
+  let(:user) { FactoryGirl.create(:user, :admin) }
+  before do
+    sign_in user
+  end
+  describe "#index" do
+    it "should find the possible solr fields" do
+      solr_fields = instance_double(SolrFieldSummary)
+      allow(SolrFieldSummary).to receive(:where).with(:field => "*").and_return(solr_fields)
+
+      get :index
+
+      expect(assigns(:solr_fields)).to eq solr_fields
+    end
+  end
+end

--- a/spec/controllers/admin/facets_controller_spec.rb
+++ b/spec/controllers/admin/facets_controller_spec.rb
@@ -9,13 +9,10 @@ RSpec.describe Admin::FacetsController do
     it "should find the possible solr fields" do
       facade = instance_double(FacetConfigurationFacade)
       allow(FacetConfigurationFacade).to receive(:new).and_return(facade)
-      new_facet = instance_double(FacetField)
-      allow(FacetField).to receive(:new).and_return(new_facet)
 
       get :index
 
       expect(assigns(:facets)).to eq facade
-      expect(assigns(:facet)).to eq new_facet
     end
   end
 

--- a/spec/controllers/admin/facets_controller_spec.rb
+++ b/spec/controllers/admin/facets_controller_spec.rb
@@ -7,14 +7,23 @@ RSpec.describe Admin::FacetsController do
   end
   describe "#index" do
     it "should find the possible solr fields" do
-      solr_fields = instance_double(SolrFieldSummary)
-      allow(SolrFieldSummary).to receive(:where).with(:field => "*").and_return(solr_fields)
-      iterator = instance_double(FacetableSolrFieldIterator)
-      allow(FacetableSolrFieldIterator).to receive(:new).with(solr_fields).and_return(iterator)
+      facade = instance_double(FacetConfigurationFacade)
+      allow(FacetConfigurationFacade).to receive(:new).and_return(facade)
+      new_facet = instance_double(FacetField)
+      allow(FacetField).to receive(:new).and_return(new_facet)
 
       get :index
 
-      expect(assigns(:solr_fields)).to eq iterator
+      expect(assigns(:facets)).to eq facade
+      expect(assigns(:facet)).to eq new_facet
+    end
+  end
+
+  describe "#create" do
+    it "should be able to make a facet" do
+      post :create, :facet_field => {:key => "test"}
+
+      expect(FacetField.first.key).to eq "test"
     end
   end
 end

--- a/spec/enumerators/facetable_solr_field_iterator_spec.rb
+++ b/spec/enumerators/facetable_solr_field_iterator_spec.rb
@@ -13,6 +13,10 @@ RSpec.describe FacetableSolrFieldIterator do
       {
         "distinct" => 5
       },
+      "title_preferred_label_ssim" =>
+      {
+        "distinct" => 300
+      },
       "alternative_ssim" =>
       {
         "distinct" => 10
@@ -26,10 +30,13 @@ RSpec.describe FacetableSolrFieldIterator do
 
   describe "#each" do
     it "should order by distinct" do
-      expect(subject.to_a.map(&:first)).to eq [:workType, :alternative, :title]
+      expect(subject.to_a.map(&:first)).to eq [:title_preferred_label, :workType, :alternative, :title]
     end
     it "should only have data model keys" do
       expect(subject.to_a.map(&:first)).not_to include :bad_key
+    end
+    it "should flatten derivative properties" do
+      expect(subject.to_a.map(&:first)).to include :title_preferred_label
     end
   end
 end

--- a/spec/enumerators/facetable_solr_field_iterator_spec.rb
+++ b/spec/enumerators/facetable_solr_field_iterator_spec.rb
@@ -1,0 +1,35 @@
+require 'rails_helper'
+
+RSpec.describe FacetableSolrFieldIterator do
+  subject { described_class.new(solr_field_summary) }
+  let(:solr_field_summary) { SolrFieldSummary.new(field_summary) }
+  let(:field_summary) do
+    {
+      "workType_ssim" => 
+      {
+        "distinct" => 36
+      },
+      "title_ssim" =>
+      {
+        "distinct" => 5
+      },
+      "alternative_ssim" =>
+      {
+        "distinct" => 10
+      },
+      "bad_key_ssim" =>
+      {
+        "distinct" => 3
+      }
+    }
+  end
+
+  describe "#each" do
+    it "should order by distinct" do
+      expect(subject.to_a.map(&:first)).to eq [:workType, :alternative, :title]
+    end
+    it "should only have data model keys" do
+      expect(subject.to_a.map(&:first)).not_to include :bad_key
+    end
+  end
+end

--- a/spec/facades/facet_configuration_facade_spec.rb
+++ b/spec/facades/facet_configuration_facade_spec.rb
@@ -1,0 +1,61 @@
+require 'rails_helper'
+
+RSpec.describe FacetConfigurationFacade do
+  subject { described_class.new }
+  before do
+    allow(SolrFieldSummary).to receive(:where).and_return(solr_summary)
+  end
+
+  let(:solr_summary) { SolrFieldSummary.new(document) }
+  let(:document) do
+    {
+      "workType_ssim" => 
+      {
+        "distinct" => 36
+      },
+      "title_ssim" =>
+      {
+        "distinct" => 5
+      },
+      "alternative_ssim" =>
+      {
+        "distinct" => 10
+      },
+      "bad_key_ssim" =>
+      {
+        "distinct" => 3
+      }
+    }
+  end
+
+  describe "#active" do
+    context "when there are no active facets" do
+      it "should be an empty hash" do
+        expect(subject.active).to be_blank
+      end
+    end
+    context "when there are active facets" do
+      it "should contain settings for them" do
+        FacetField.create(:key => "title")
+
+        expect(subject.active.to_h.keys.first).to eq :title
+        expect(subject.active.to_h.values.first.distinct).to eq 5
+      end
+    end
+  end
+
+  describe "#inactive" do
+    context "when there are no active facets" do
+      it "should have all the fields" do
+        expect(subject.inactive.to_h.keys).to eq [:workType, :alternative, :title]
+      end
+    end
+    context "when there are active facets" do
+      it "should have only the non-active fields" do
+        FacetField.create(:key => "title")
+        
+        expect(subject.inactive.to_h.keys).to eq [:workType, :alternative]
+      end
+    end
+  end
+end

--- a/spec/facades/facet_configuration_facade_spec.rb
+++ b/spec/facades/facet_configuration_facade_spec.rb
@@ -36,10 +36,11 @@ RSpec.describe FacetConfigurationFacade do
     end
     context "when there are active facets" do
       it "should contain settings for them" do
-        FacetField.create(:key => "title")
+        facet = FacetField.create(:key => "title")
 
         expect(subject.active.to_h.keys.first).to eq :title
         expect(subject.active.to_h.values.first.distinct).to eq 5
+        expect(subject.active.to_h.values.first.facet).to eq facet
       end
     end
   end
@@ -48,6 +49,7 @@ RSpec.describe FacetConfigurationFacade do
     context "when there are no active facets" do
       it "should have all the fields" do
         expect(subject.inactive.to_h.keys).to eq [:workType, :alternative, :title]
+        expect(subject.inactive.to_h[:workType].facet).not_to be_persisted
       end
     end
     context "when there are active facets" do

--- a/spec/factories/facet_fields.rb
+++ b/spec/factories/facet_fields.rb
@@ -1,0 +1,6 @@
+FactoryGirl.define do
+  factory :facet_field do
+    key "MyString"
+  end
+
+end

--- a/spec/models/blacklight_config_spec.rb
+++ b/spec/models/blacklight_config_spec.rb
@@ -72,6 +72,13 @@ RSpec.describe BlacklightConfig do
       expect(labels).to include "Alternative"
       expect(keys).to include *GenericAsset.properties.keys.map{|x| "#{x}_ssim"}
     end
+    
+    it "should have facets for all the facet fields" do
+      FacetField.create(:key => "title")
+
+      keys = subject.facet_fields.values.map(&:key)
+      expect(keys).to include "title_ssim"
+    end
 
     it "should have a tool config for edit" do
       expect(subject.show.document_actions[:edit_record].partial).to eq "edit_action"

--- a/spec/models/blacklight_config_spec.rb
+++ b/spec/models/blacklight_config_spec.rb
@@ -77,7 +77,9 @@ RSpec.describe BlacklightConfig do
       FacetField.create(:key => "title")
 
       keys = subject.facet_fields.values.map(&:key)
+      labels = subject.facet_fields.values.map(&:label)
       expect(keys).to include "title_ssim"
+      expect(labels).to include "Title"
     end
 
     it "should have a tool config for edit" do

--- a/spec/models/facet_field_spec.rb
+++ b/spec/models/facet_field_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe FacetField, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/facet_field_spec.rb
+++ b/spec/models/facet_field_spec.rb
@@ -1,5 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe FacetField, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  describe "validations" do
+    it { should validate_presence_of :key }
+  end
 end

--- a/spec/models/solr_field_summary/query_spec.rb
+++ b/spec/models/solr_field_summary/query_spec.rb
@@ -1,0 +1,14 @@
+require 'rails_helper'
+
+RSpec.describe SolrFieldSummary::Query do
+  subject { described_class.new(field: "*") }
+  describe "#result" do
+    it "should return the solr result" do
+      GenericAsset.create do |c|
+        c.title = ["Test"]
+      end
+
+      expect(subject.result.keys).to include "title_ssim"
+    end
+  end
+end

--- a/spec/models/solr_field_summary_spec.rb
+++ b/spec/models/solr_field_summary_spec.rb
@@ -56,10 +56,7 @@ RSpec.describe SolrFieldSummary do
       expect(subject[:banana]).to eq nil
     end
     it "should add derivative keys" do
-      expect(subject[:title].derivative_properties[:preferred_label].distinct).to eq 36
-    end
-    it "should not give derivative keys its own property" do
-      expect(subject.keys).to eq [:title]
+      expect(subject[:title_preferred_label].distinct).to eq 36
     end
     it "should only do ssim keys" do
       expect(subject[:title].dynamicBase).to eq "*_ssim"

--- a/spec/models/solr_field_summary_spec.rb
+++ b/spec/models/solr_field_summary_spec.rb
@@ -35,7 +35,14 @@ RSpec.describe SolrFieldSummary do
           "topTerms" => [
             "Test",
             "Test2"
-          ]
+          ],
+          "dynamicBase" => "*_ssim"
+        },
+        "title_tesim" => 
+        {
+          "docs" => 10,
+          "distinct" => 6,
+          "dynamicBase" => "*_tesim"
         }
       }
     end
@@ -53,6 +60,9 @@ RSpec.describe SolrFieldSummary do
     end
     it "should not give derivative keys its own property" do
       expect(subject.keys).to eq [:title]
+    end
+    it "should only do ssim keys" do
+      expect(subject[:title].dynamicBase).to eq "*_ssim"
     end
   end
 end

--- a/spec/models/solr_field_summary_spec.rb
+++ b/spec/models/solr_field_summary_spec.rb
@@ -66,16 +66,3 @@ RSpec.describe SolrFieldSummary do
     end
   end
 end
-
-RSpec.describe SolrFieldSummary::Query do
-  subject { described_class.new(field: "*") }
-  describe "#result" do
-    it "should return the solr result" do
-      GenericAsset.create do |c|
-        c.title = ["Test"]
-      end
-
-      expect(subject.result.keys).to include "title_ssim"
-    end
-  end
-end

--- a/spec/models/solr_field_summary_spec.rb
+++ b/spec/models/solr_field_summary_spec.rb
@@ -1,0 +1,71 @@
+require 'rails_helper'
+
+RSpec.describe SolrFieldSummary do
+  describe ".where" do
+    context "when given a field" do
+      subject { described_class.where(:field => "*") }
+      it "should return a field summary" do
+        GenericAsset.create do |c|
+          c.title = ["Test"]
+        end
+
+        expect(subject).to be_kind_of SolrFieldSummary
+        expect(subject["title"].distinct).to eq 1
+      end
+    end
+  end
+
+  describe "[]" do
+    subject { described_class.new(field_document) }
+    let(:field_document) do
+      {
+        "title_preferred_label_ssim" => 
+        {
+          "docs" => 36,
+          "distinct" => 36,
+          "topTerms" => [
+            "Label",
+            "Other Label"
+          ]
+        },
+        "title_ssim" =>
+        {
+          "docs" => 10,
+          "distinct" => 6,
+          "topTerms" => [
+            "Test",
+            "Test2"
+          ]
+        }
+      }
+    end
+    it "should access by the base property name" do
+      expect(subject["title"]).to be_kind_of SolrFieldSummary::Field
+    end
+    it "should work with symbols as a key" do
+      expect(subject[:title]).to be_kind_of SolrFieldSummary::Field
+    end
+    it "should not work for non-existent properties" do
+      expect(subject[:banana]).to eq nil
+    end
+    it "should add derivative keys" do
+      expect(subject[:title].derivative_properties[:preferred_label].distinct).to eq 36
+    end
+    it "should not give derivative keys its own property" do
+      expect(subject.keys).to eq [:title]
+    end
+  end
+end
+
+RSpec.describe SolrFieldSummary::Query do
+  subject { described_class.new(field: "*") }
+  describe "#result" do
+    it "should return the solr result" do
+      GenericAsset.create do |c|
+        c.title = ["Test"]
+      end
+
+      expect(subject.result.keys).to include "title_ssim"
+    end
+  end
+end

--- a/spec/routing/admin_facet_routing_spec.rb
+++ b/spec/routing/admin_facet_routing_spec.rb
@@ -7,4 +7,7 @@ RSpec.describe "facet admin routing" do
   it "should route post /admin/facets to facets#create" do
     expect(post '/admin/facets').to route_to :controller => "admin/facets", :action => "create"
   end
+  it "should route delete /admin/facet/1 to facets#destroy" do
+    expect(delete '/admin/facets/1').to route_to :controller => "admin/facets", :action => "destroy", :id => "1"
+  end
 end

--- a/spec/routing/admin_facet_routing_spec.rb
+++ b/spec/routing/admin_facet_routing_spec.rb
@@ -4,4 +4,7 @@ RSpec.describe "facet admin routing" do
   it "should route /admin/facets to facets#index" do
     expect(get '/admin/facets').to route_to :controller => "admin/facets", :action => "index"
   end
+  it "should route post /admin/facets to facets#create" do
+    expect(post '/admin/facets').to route_to :controller => "admin/facets", :action => "create"
+  end
 end

--- a/spec/routing/admin_facet_routing_spec.rb
+++ b/spec/routing/admin_facet_routing_spec.rb
@@ -1,0 +1,7 @@
+require 'rails_helper'
+
+RSpec.describe "facet admin routing" do
+  it "should route /admin/facets to facets#index" do
+    expect(get '/admin/facets').to route_to :controller => "admin/facets", :action => "index"
+  end
+end

--- a/spec/support/shoulda.rb
+++ b/spec/support/shoulda.rb
@@ -1,0 +1,1 @@
+require 'shoulda/matchers'

--- a/spec/views/admin/facets/index.html.erb_spec.rb
+++ b/spec/views/admin/facets/index.html.erb_spec.rb
@@ -1,0 +1,34 @@
+require 'rails_helper'
+
+RSpec.describe "admin/facets/index.html.erb" do
+  let(:facade) { FacetConfigurationFacade.new }
+  context "when there are assets and facets" do
+    let(:facet) { FacetField.create(:key => "title") }
+    before do
+      create_asset
+      facet
+      assign(:facets, facade)
+      render
+    end
+
+    it "should have a destroy button for the existing facet field" do
+      expect(rendered).to have_link "Delete", :href => admin_facet_path(:id => facet.id)
+    end
+    it "should have a create button" do
+      expect(rendered).to have_button "Enable Alternative Facet"
+    end
+    it "should show top terms" do
+      expect(rendered).to have_content "Alphabet Soup"
+      expect(rendered).to have_content "Invasion of the Bananas"
+    end
+
+    def create_asset
+      asset_document = GenericAsset.new do |c|
+        c.title = ["Alphabet Soup"]
+        c.alternative = ["Invasion of the Bananas"]
+      end.to_solr.merge({"id" => "s9as9z"})
+      ActiveFedora.solr.conn.add asset_document
+      ActiveFedora.solr.conn.commit
+    end
+  end
+end

--- a/spec/views/admin/index.html.erb_spec.rb
+++ b/spec/views/admin/index.html.erb_spec.rb
@@ -14,8 +14,13 @@ RSpec.describe 'admin/index' do
     context "when ingesting a new record" do
       it "should have a link to ingest a new record" do
         expect(rendered).to have_link "Ingest a New Record", :href => hydra_editor.new_record_path
+      end
+      it "should have a link to edit roles" do
         expect(rendered).to have_link "Edit User Roles", :href => role_management.roles_path
-     end
+      end
+      it "should have a link to configure facets" do
+        expect(rendered).to have_link "Configure Facets", :href => admin_facets_path
+      end
     end
   end
 end


### PR DESCRIPTION
Enables database configurable facets for fields in the OD Data Model. Allows you to facet on any field indexed as a symbol, including enhancements.

Does NOT currently let you choose a label for your facets - didn't want to add more to this PR, and couldn't think of a good UI for it.