### PR TITLE
Speedup tests

### DIFF
--- a/spec/features/sets_show_spec.rb
+++ b/spec/features/sets_show_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe "Sets show page" do
+RSpec.describe "Sets show page", :slow => true do
   it "should be able to display an asset" do
     set = GenericSet.create(:read_groups => ["public"])
     asset = GenericAsset.create(:title => ["Test Title"], :read_groups => ["public"], :set => [set])

--- a/spec/lib/oregon_digital/set_fixer_spec.rb
+++ b/spec/lib/oregon_digital/set_fixer_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe OregonDigital::SetFixer do
+RSpec.describe OregonDigital::SetFixer, :slow => true do
   subject { described_class.new(solr_service, base) }
 
   let(:solr_service) { ActiveFedora::SolrService }

--- a/spec/services/enricher_spec.rb
+++ b/spec/services/enricher_spec.rb
@@ -4,9 +4,13 @@ RSpec.describe Enricher do
   subject { described_class.new(id) }
   let(:id) { asset.id }
   let(:asset) do
-    GenericAsset.create do |g|
+    a = GenericAsset.new do |g|
       g.lcsubject = [uri]
     end
+    allow(a).to receive(:id).and_return("yo")
+    solr.add a.to_solr.merge(:id => a.id)
+    solr.commit
+    a
   end
   let(:uri) { resource.rdf_subject }
   let(:resource) do
@@ -15,6 +19,7 @@ RSpec.describe Enricher do
     r.persist!
     r
   end
+  let(:solr) { ActiveFedora.solr.conn }
 
   describe "#enrich!" do
     it "should enrich the solr document" do


### PR DESCRIPTION
Marked some integration specs as CI only, since they should always pass as long as the unit tests do. Made the Enricher just deal with Solr.